### PR TITLE
show commets w/ null user as by 'A Google user' to match dev console

### DIFF
--- a/src/com/github/andlyticsproject/CommentsActivity.java
+++ b/src/com/github/andlyticsproject/CommentsActivity.java
@@ -313,35 +313,35 @@ public class CommentsActivity extends BaseDetailsActivity {
 				return;
 			}
 
+			activity.refreshFinished();
 			activity.footer.setEnabled(true);
 
 			if (exception != null) {
 				Log.e(TAG, "Error fetching comments: " + exception.getMessage(), exception);
 				activity.handleUserVisibleException(exception);
 				activity.footer.setVisibility(View.GONE);
-			} else {
-				activity.footer.setVisibility(View.VISIBLE);
 
-				if (activity.comments != null && activity.comments.size() > 0) {
-
-					activity.commentsListAdapter.setCommentGroups(activity.commentGroups);
-					for (int i = 0; i < activity.commentGroups.size(); i++) {
-						activity.list.expandGroup(i);
-					}
-					activity.commentsListAdapter.notifyDataSetChanged();
-				} else {
-					activity.nocomments.setVisibility(View.VISIBLE);
-				}
-
-				if (!activity.hasMoreComments) {
-					activity.footer.setVisibility(View.GONE);
-				}
-
-				Preferences.saveLastCommentsRemoteUpdateTime(activity, activity.packageName,
-						System.currentTimeMillis());
+				return;
 			}
 
-			activity.refreshFinished();
+			activity.footer.setVisibility(View.VISIBLE);
+
+			if (activity.comments != null && activity.comments.size() > 0) {
+				activity.commentsListAdapter.setCommentGroups(activity.commentGroups);
+				for (int i = 0; i < activity.commentGroups.size(); i++) {
+					activity.list.expandGroup(i);
+				}
+				activity.commentsListAdapter.notifyDataSetChanged();
+			} else {
+				activity.nocomments.setVisibility(View.VISIBLE);
+			}
+
+			if (!activity.hasMoreComments) {
+				activity.footer.setVisibility(View.GONE);
+			}
+
+			Preferences.saveLastCommentsRemoteUpdateTime(activity, activity.packageName,
+					System.currentTimeMillis());
 		}
 
 	}

--- a/src/com/github/andlyticsproject/CommentsListAdapter.java
+++ b/src/com/github/andlyticsproject/CommentsListAdapter.java
@@ -31,7 +31,7 @@ public class CommentsListAdapter extends BaseExpandableListAdapter {
 	private ArrayList<CommentGroup> commentGroups;
 
 	private CommentsActivity context;
-	
+
 	private DateFormat commentDateFormat = DateFormat.getDateInstance(DateFormat.FULL);
 
 
@@ -50,15 +50,17 @@ public class CommentsListAdapter extends BaseExpandableListAdapter {
 		ViewHolderChild holder;
 
 		if (convertView == null) {
-			convertView = layoutInflater.inflate(comment.isReply() ? R.layout.comments_list_item_reply
-					: R.layout.comments_list_item_comment, null);
+			convertView = layoutInflater.inflate(
+					comment.isReply() ? R.layout.comments_list_item_reply
+							: R.layout.comments_list_item_comment, null);
 
 			holder = new ViewHolderChild();
 			holder.text = (TextView) convertView.findViewById(R.id.comments_list_item_text);
 			holder.user = (TextView) convertView.findViewById(R.id.comments_list_item_username);
 			holder.date = (TextView) convertView.findViewById(R.id.comments_list_item_date);
 			holder.device = (TextView) convertView.findViewById(R.id.comments_list_item_device);
-			holder.rating = (RatingBar) convertView.findViewById(R.id.comments_list_item_app_ratingbar);
+			holder.rating = (RatingBar) convertView
+					.findViewById(R.id.comments_list_item_app_ratingbar);
 
 			convertView.setTag(holder);
 		} else {
@@ -69,7 +71,7 @@ public class CommentsListAdapter extends BaseExpandableListAdapter {
 		if (comment.isReply()) {
 			holder.date.setText(formatCommentDate(comment.getReplyDate()));
 		} else {
-			holder.user.setText(comment.getUser());
+			holder.user.setText(comment.getUser() == null ? "A Google User" : comment.getUser());
 			String version = comment.getAppVersion();
 			String device = comment.getDevice();
 			String deviceText = "";
@@ -126,7 +128,6 @@ public class CommentsListAdapter extends BaseExpandableListAdapter {
 	public int getChildType(int groupPosition, int childPosition) {
 		return getChild(groupPosition, childPosition).isReply() ? TYPE_REPLY : TYPE_COMMENT;
 	}
-
 
 
 	@Override
@@ -218,7 +219,7 @@ public class CommentsListAdapter extends BaseExpandableListAdapter {
 	public ArrayList<CommentGroup> getCommentGroups() {
 		return commentGroups;
 	}
-	
+
 	private String formatCommentDate(Date date) {
 		return commentDateFormat.format(date);
 	}

--- a/src/com/github/andlyticsproject/console/v2/JsonParser.java
+++ b/src/com/github/andlyticsproject/console/v2/JsonParser.java
@@ -1,4 +1,3 @@
-
 package com.github.andlyticsproject.console.v2;
 
 import java.util.ArrayList;
@@ -20,9 +19,9 @@ import com.github.andlyticsproject.model.Comment;
  *
  */
 public class JsonParser {
-	
+
 	private JsonParser() {
-		
+
 	}
 
 	/**
@@ -51,8 +50,7 @@ public class JsonParser {
 	 * @param statsType
 	 * @throws JSONException
 	 */
-	static void parseStatistics(String json, AppStats stats, int statsType)
-			throws JSONException {
+	static void parseStatistics(String json, AppStats stats, int statsType) throws JSONException {
 		// Extract the top level values array
 		JSONArray values = new JSONObject(json).getJSONArray("result").getJSONArray(1);
 		/*
@@ -79,13 +77,13 @@ public class JsonParser {
 
 		switch (statsType) {
 		case DevConsoleV2Protocol.STATS_TYPE_TOTAL_USER_INSTALLS:
-				stats.setTotalDownloads(latestValue);
-				break;
+			stats.setTotalDownloads(latestValue);
+			break;
 		case DevConsoleV2Protocol.STATS_TYPE_ACTIVE_DEVICE_INSTALLS:
-				stats.setActiveInstalls(latestValue);
-				break;
-			default:
-				break;
+			stats.setActiveInstalls(latestValue);
+			break;
+		default:
+			break;
 		}
 
 	}
@@ -97,8 +95,7 @@ public class JsonParser {
 	 * @return List of apps
 	 * @throws JSONException
 	 */
-	static List<AppInfo> parseAppInfos(String json, String accountName)
-			throws JSONException {
+	static List<AppInfo> parseAppInfos(String json, String accountName) throws JSONException {
 
 		Date now = new Date();
 		List<AppInfo> apps = new ArrayList<AppInfo>();
@@ -137,8 +134,8 @@ public class JsonParser {
 			JSONArray jsonAppInfo = jsonApp.getJSONArray(1);
 			String packageName = jsonAppInfo.getString(1);
 			// Look for "tmp.7238057230750432756094760456.235728507238057230542"
-			if (packageName == null || (packageName.startsWith("tmp.")
-					&& Character.isDigit(packageName.charAt(4)))) {
+			if (packageName == null
+					|| (packageName.startsWith("tmp.") && Character.isDigit(packageName.charAt(4)))) {
 				break;
 				// Draft app
 			}
@@ -224,7 +221,7 @@ public class JsonParser {
 	 * @throws JSONException
 	 */
 	static List<Comment> parseComments(String json) throws JSONException {
-		List<Comment> comments  = new ArrayList<Comment>();
+		List<Comment> comments = new ArrayList<Comment>();
 		/*
 		 * null
 		 * Array containing arrays of comments
@@ -282,7 +279,10 @@ public class JsonParser {
 			   1
 			]
 			 */
-			comment.setUser(jsonComment.getString(2));
+			String user = jsonComment.getString(2);
+			if (user != null && !"null".equals(user)) {
+				comment.setUser(user);
+			}
 			comment.setDate(parseDate(jsonComment.getLong(3)));
 			comment.setRating(jsonComment.getInt(4));
 			String version = jsonComment.getString(8);
@@ -309,8 +309,8 @@ public class JsonParser {
 				comment.setReply(reply);
 			}
 
-			comments.add(comment);			
-		}		
+			comments.add(comment);
+		}
 
 		return comments;
 	}
@@ -320,7 +320,7 @@ public class JsonParser {
 	 * @param unixDateCode
 	 * @return
 	 */
-	private static Date parseDate(long unixDateCode){
+	private static Date parseDate(long unixDateCode) {
 		return new Date(unixDateCode);
 	}
 


### PR DESCRIPTION
Seems the rumoured transition to commenting via G+ is under way? All comments are now shown as by "A Google User" in the dev console. Matching that, further changes might be needed as/if this develops. 
