### PR TITLE
Added "Month to Date" Time Frame Option

### DIFF
--- a/res/menu-land/charts_menu.xml
+++ b/res/menu-land/charts_menu.xml
@@ -32,6 +32,9 @@
                 <item
                     android:id="@+id/itemChartsmenuTimeframeUnlimited"
                     android:title="@string/unlimited"/>
+                <item
+                    android:id="@+id/itemChartsmenuTimeframeMonthToDate"
+                    android:title="@string/month_to_date"/>
             </group>
         </menu>
     </item>

--- a/res/menu-large-land/charts_menu.xml
+++ b/res/menu-large-land/charts_menu.xml
@@ -26,6 +26,9 @@
                 <item
                     android:id="@+id/itemChartsmenuTimeframeUnlimited"
                     android:title="@string/unlimited"/>
+                <item
+                    android:id="@+id/itemChartsmenuTimeframeMonthToDate"
+                    android:title="@string/month_to_date"/>
             </group>
         </menu>
     </item>

--- a/res/menu-w480dp-port/charts_menu.xml
+++ b/res/menu-w480dp-port/charts_menu.xml
@@ -26,6 +26,9 @@
                 <item
                     android:id="@+id/itemChartsmenuTimeframeUnlimited"
                     android:title="@string/unlimited"/>
+                <item
+                    android:id="@+id/itemChartsmenuTimeframeMonthToDate"
+                    android:title="@string/month_to_date"/>
             </group>
         </menu>
     </item>

--- a/res/menu-w700dp-port/charts_menu.xml
+++ b/res/menu-w700dp-port/charts_menu.xml
@@ -26,6 +26,9 @@
                 <item
                     android:id="@+id/itemChartsmenuTimeframeUnlimited"
                     android:title="@string/unlimited"/>
+                <item
+                    android:id="@+id/itemChartsmenuTimeframeMonthToDate"
+                    android:title="@string/month_to_date"/>
             </group>
         </menu>
     </item>

--- a/res/menu/charts_menu.xml
+++ b/res/menu/charts_menu.xml
@@ -26,6 +26,9 @@
                 <item
                     android:id="@+id/itemChartsmenuTimeframeUnlimited"
                     android:title="@string/unlimited"/>
+                <item
+                    android:id="@+id/itemChartsmenuTimeframeMonthToDate"
+                    android:title="@string/month_to_date"/>
             </group>
         </menu>
     </item>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="thirty_days">Last 30 days</string>
     <string name="ninety_days">Last 90 days</string>
     <string name="unlimited">Unlimited</string>
+    <string name="month_to_date">Month to Date</string>
     <string name="date_format">Date format</string>
     <string name="locale_default">Locale default</string>
     <string name="ddmmyy">Day/Month/Year</string>

--- a/src/com/github/andlyticsproject/BaseChartActivity.java
+++ b/src/com/github/andlyticsproject/BaseChartActivity.java
@@ -127,6 +127,10 @@ public abstract class BaseChartActivity extends BaseDetailsActivity implements
 			activeTimeFrame = menu
 					.findItem(R.id.itemChartsmenuTimeframeUnlimited);
 			break;
+		case MONTH_TO_DATE:
+			activeTimeFrame = menu
+					.findItem(R.id.itemChartsmenuTimeframeMonthToDate);
+			break;
 		}
 		activeTimeFrame.setChecked(true);
 
@@ -180,6 +184,13 @@ public abstract class BaseChartActivity extends BaseDetailsActivity implements
 			currentTimeFrame = Timeframe.UNLIMITED;
 			executeLoadData(currentTimeFrame);
 			Preferences.saveChartTimeframe(Timeframe.UNLIMITED,
+					BaseChartActivity.this);
+			item.setChecked(true);
+			return true;
+		case R.id.itemChartsmenuTimeframeMonthToDate:
+			currentTimeFrame = Timeframe.MONTH_TO_DATE;
+			executeLoadData(currentTimeFrame);
+			Preferences.saveChartTimeframe(Timeframe.MONTH_TO_DATE,
 					BaseChartActivity.this);
 			item.setChecked(true);
 			return true;

--- a/src/com/github/andlyticsproject/ContentAdapter.java
+++ b/src/com/github/andlyticsproject/ContentAdapter.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
@@ -74,6 +75,8 @@ public class ContentAdapter {
 			limit = 2;
 		} else if (currentTimeFrame.equals(Timeframe.LATEST_VALUE)) {
 			limit = 1;
+		} else if (currentTimeFrame.equals(Timeframe.MONTH_TO_DATE)) {
+			limit = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
 		}
 
 		Cursor cursor = context.getContentResolver().query(
@@ -582,6 +585,8 @@ public class ContentAdapter {
 			limit = 2;
 		} else if (currentTimeFrame.equals(Timeframe.LATEST_VALUE)) {
 			limit = 1;
+		} else if (currentTimeFrame.equals(Timeframe.MONTH_TO_DATE)) {
+			limit = Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
 		}
 
 		Cursor cursor = context.getContentResolver().query(

--- a/src/com/github/andlyticsproject/Preferences.java
+++ b/src/com/github/andlyticsproject/Preferences.java
@@ -68,7 +68,7 @@ public class Preferences {
 	public static final String USE_GOOGLE_TRANSLATE_APP = "use.google.translate.app";
 
 	public enum Timeframe {
-		LAST_NINETY_DAYS, LAST_THIRTY_DAYS, UNLIMITED, LAST_TWO_DAYS, LATEST_VALUE, LAST_SEVEN_DAYS
+		LAST_NINETY_DAYS, LAST_THIRTY_DAYS, UNLIMITED, LAST_TWO_DAYS, LATEST_VALUE, LAST_SEVEN_DAYS, MONTH_TO_DATE
 	}
 
 	public enum StatsMode {


### PR DESCRIPTION
Modified strings.xml to add "Month to Date" String (No translations sorry)
Modified charts_menu.xml files to Add "Month to Date" Option
Modified Prefernces.java to add "MONTH_TO_DATE" to Timeframe enum
Modified BaseChartActivity.java to include "MONTH_TO_DATE" in onCreateOptionsMenu() and onOptionsItemSelected(). Copied the functionality of the other options (Note: I've re-wrote and recommited BaseChartActivity.java several times now, and every time I commit on the local github client, it displays just the lines I've changed and once I sync back to GitHub it trashes that and just says I've changed the entire file _Grumble_ Its doing my nut...)
Modified ContentAdapter.java to include "MONTH_TO_DATE" to getAdmobStats() and getStatsForApp(). Using Calendar.getInstance().get(Calendar.DAY_OF_MONTH); to grab the day of the month to set again the limit.
