### PR TITLE
new feature: links associated with apps.

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -47,6 +47,10 @@
             android:label="@string/comments" >
         </activity>
         <activity
+            android:name=".LinksActivity"
+            android:label="@string/links" >
+        </activity>
+        <activity
             android:name=".ChartActivity"
             android:label="@string/app_name" >
         </activity>

--- a/res/layout/crash_dialog.xml
+++ b/res/layout/crash_dialog.xml
@@ -10,7 +10,6 @@
 
 	<LinearLayout
 		android:layout_height="0dp"
-		xmlns:android="http://schemas.android.com/apk/res/android"
 		android:orientation="vertical"
 		android:gravity="center"
 		android:layout_width="fill_parent"

--- a/res/layout/links.xml
+++ b/res/layout/links.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/links_list_frame"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:background="@color/andBackground"
+    android:inAnimation="@anim/view_switcher_fade_in"
+    android:outAnimation="@anim/view_switcher_fade_out" >
+
+    <ListView
+        android:id="@+id/links_list"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:background="@color/andBackground"
+        android:cacheColorHint="#00000000"
+        android:divider="@color/andBackground"
+        android:dividerHeight="1dp"
+        android:paddingLeft="5dp"
+        android:paddingRight="5dp"
+        android:paddingTop="5dp" />
+
+    <RelativeLayout
+        android:id="@+id/links_nolinks"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:background="@color/andBackground"
+        android:visibility="gone" >
+
+        <TextView
+            style="@style/MainTableText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerHorizontal="true"
+            android:layout_centerVertical="true"
+            android:gravity="center"
+            android:padding="10dp"
+            android:text="@string/no_links_found"
+            android:textStyle="normal" />
+    </RelativeLayout>
+
+</RelativeLayout>

--- a/res/layout/links_addedit_dialog.xml
+++ b/res/layout/links_addedit_dialog.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/modal_dialog"
+    android:orientation="vertical" >
+
+    <ScrollView
+        android:layout_width="fill_parent"
+        android:layout_height="0dip"
+        android:layout_weight="1" >
+
+        <LinearLayout
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingBottom="5dip"
+            android:paddingLeft="20dip"
+            android:paddingRight="20dip"
+            android:paddingTop="5dip" >
+
+            <TextView
+                android:id="@+id/links_addedit_dialog_title"
+                style="@style/MainTableHeadline"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginBottom="8dp"
+                android:layout_marginTop="8dp"
+                android:gravity="center"
+                android:text="@string/links_addedit_dialog_title_add"
+                android:textSize="18dp"
+                android:textStyle="bold" />
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="1dp"
+                android:background="@color/andBorder" />
+
+            <TextView
+                android:id="@+id/links_addedit_dialog_text"
+                style="@style/MainTableText"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:paddingBottom="10dp"
+                android:paddingLeft="10dp"
+                android:paddingRight="10dp"
+                android:paddingTop="10dp"
+                android:text="@string/links_addedit_dialog_text" />
+
+            <Button
+                android:id="@+id/links_addedit_dialog_url_marketbutton"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/links_addedit_dialog_url_marketbutton" >
+            </Button>
+
+            <TextView
+                style="@style/MainTableText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/links_addedit_dialog_url_label"
+                android:textAppearance="?android:attr/textAppearanceSmall" />
+
+            <EditText
+                android:id="@+id/links_addedit_dialog_url_input"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textUri"
+                android:minWidth="250dip"
+                android:scrollHorizontally="true"
+                android:singleLine="true"
+                android:textSize="12dp" >
+
+                <requestFocus />
+            </EditText>
+
+            <TextView
+                style="@style/MainTableText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/links_addedit_dialog_name_label"
+                android:textAppearance="?android:attr/textAppearanceSmall" />
+
+            <EditText
+                android:id="@+id/links_addedit_dialog_name_input"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:minWidth="250dip"
+                android:scrollHorizontally="true"
+                android:singleLine="true"
+                android:textSize="12dp" >
+            </EditText>
+        </LinearLayout>
+    </ScrollView>
+
+    <LinearLayout
+        android:id="@+id/links_addedit_dialog_button_frame"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal" >
+
+        <RelativeLayout
+            android:id="@+id/links_addedit_dialog_positive_button"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="5dp"
+            android:layout_weight="1"
+            android:background="@drawable/image_button"
+            android:padding="5dp" >
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingRight="5dp"
+                android:src="@drawable/icon_logout"
+                android:visibility="invisible" />
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerHorizontal="true"
+                android:layout_centerVertical="true"
+                android:orientation="horizontal" >
+
+                <TextView
+                    android:id="@+id/links_addedit_dialog_positive_button_text"
+                    style="@style/MainTableText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:text="@string/ok"
+                    android:textColor="#fff"
+                    android:textStyle="bold" />
+            </LinearLayout>
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:id="@+id/links_addedit_dialog_negative_button"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="5dp"
+            android:layout_weight="1"
+            android:background="@drawable/image_button"
+            android:padding="5dp" >
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingRight="5dp"
+                android:src="@drawable/icon_logout"
+                android:visibility="invisible" />
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerHorizontal="true"
+                android:layout_centerVertical="true"
+                android:orientation="horizontal" >
+
+                <TextView
+                    android:id="@+id/links_addedit_dialog_negative_button_text"
+                    style="@style/MainTableText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:text="@string/cancel"
+                    android:textColor="#fff"
+                    android:textStyle="bold" />
+            </LinearLayout>
+        </RelativeLayout>
+    </LinearLayout>
+</LinearLayout>

--- a/res/layout/links_list_item.xml
+++ b/res/layout/links_list_item.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/links_list_item_app_row"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/row_background"  android:descendantFocusability="blocksDescendants" >
+
+    <RelativeLayout
+        android:id="@+id/links_list_item_link_container"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:paddingBottom="5dp">
+
+        <TextView
+            android:id="@+id/links_list_item_name"
+            style="@style/MainTableText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingLeft="15dp"
+            android:paddingRight="10dp"
+            android:paddingTop="10dp" />
+
+        <TextView
+            android:id="@+id/links_list_item_url"
+            style="@style/MainTableText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/links_list_item_name"
+            android:autoLink="all"
+            android:paddingLeft="15dp"
+            android:paddingRight="15dp"
+            android:textStyle="bold" />
+    </RelativeLayout>
+
+    <View
+        android:id="@+id/links_list_item_shadow"
+        android:layout_width="fill_parent"
+        android:layout_height="1dp"
+        android:layout_below="@+id/links_list_item_link_container"
+        android:layout_marginLeft="10dp"
+        android:layout_marginRight="10dp"
+        android:background="@color/andBackgroundDarkHighlight"
+        android:paddingTop="1dp" />
+
+</RelativeLayout>

--- a/res/menu/links_menu.xml
+++ b/res/menu/links_menu.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android" >    
+    <item
+        android:id="@+id/itemLinksmenuAdd"        
+        android:icon="@drawable/icon_add"
+        android:showAsAction="ifRoom"
+        android:title="@string/add">
+    </item>
+</menu>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="admob_requests">AdMob requests</string>
     <string name="average_rating">Average rating</string>
     <string name="ratings">Ratings</string>
+    <string name="links">Links</string>
     <!-- Lower case versions for main screen e.g. X comments -->
     <string name="num_comments">comments</string>
     <string name="num_total_downloads">total downloads</string>
@@ -50,6 +51,9 @@
     <string name="run_import">Run import</string>
     <string name="cancel">Cancel</string>
     <string name="ok">OK</string>
+    <string name="add">Add</string>
+    <string name="edit">Edit</string>
+    <string name="delete">Delete</string>
     <string name="title">Title</string>
     <string name="text">Text</string>
     <string name="select_files_export">Select apps to export</string>
@@ -61,6 +65,7 @@
     <string name="load_more_comments">Load more comments</string>
     <string name="info_comments">The number of comments reported on the main screen may be higher than the number of comments shown here because of withdrawn / changed comments.</string>
     <string name="no_comments_found">No comments found</string>
+    <string name="no_links_found">No links found</string>
     <string name="time_frame">Time frame</string>
     <string name="seven_days">Last 7 days</string>
     <string name="thirty_days">Last 30 days</string>
@@ -178,4 +183,13 @@
     <string name="about_credits">Credits</string>
 	<string name="about_text">Andlytics is open source, please feel free to contribute via GitHub. This app is not associated with Google in any way.\n\nVisit us on:</string>
 	<string name="about_thirdsparty_credits_title">Used 3rd party libraries:</string>
+	
+	<string name="links_addedit_dialog_title_add">ADD LINK</string>
+	<string name="links_addedit_dialog_title_edit">EDIT LINK</string>
+	<string name="links_addedit_dialog_text">This form accepts any http or https URL. market:// links are not supported.</string>
+	<string name="links_addedit_dialog_url_label">URL</string>
+	<string name="links_addedit_dialog_url_marketbutton">Use your market link</string>
+	<string name="links_addedit_dialog_name_label">Name</string>
+	<string name="links_addedit_dialog_name_hint">Leave blank to use a default value</string>
+	<string name="links_addedit_dialog_not_url">Your URL does not parse as a URL.</string>
 </resources>

--- a/src/com/github/andlyticsproject/ContentAdapter.java
+++ b/src/com/github/andlyticsproject/ContentAdapter.java
@@ -26,12 +26,14 @@ import com.github.andlyticsproject.db.AndlyticsContentProvider;
 import com.github.andlyticsproject.db.AppInfoTable;
 import com.github.andlyticsproject.db.AppStatsTable;
 import com.github.andlyticsproject.db.CommentsTable;
+import com.github.andlyticsproject.db.LinksTable;
 import com.github.andlyticsproject.model.Admob;
 import com.github.andlyticsproject.model.AdmobList;
 import com.github.andlyticsproject.model.AppInfo;
 import com.github.andlyticsproject.model.AppStats;
 import com.github.andlyticsproject.model.AppStatsList;
 import com.github.andlyticsproject.model.Comment;
+import com.github.andlyticsproject.model.Link;
 
 public class ContentAdapter {
 
@@ -1198,4 +1200,69 @@ public class ContentAdapter {
 		return result;
 	}
 
+
+	public ArrayList<Link> getLinksByPackageName(String packageName) {
+		ArrayList<Link> result = new ArrayList<Link>();
+
+		Cursor cursor = null;
+		try {
+			cursor = context.getContentResolver()
+					.query(LinksTable.CONTENT_URI,
+							new String[] { LinksTable.KEY_ROWID,
+									LinksTable.KEY_LINK_NAME,
+									LinksTable.KEY_LINK_URL },
+							AppInfoTable.KEY_APP_PACKAGENAME + " = ?",
+							new String[] { packageName },
+							LinksTable.KEY_LINK_NAME);
+			if (cursor == null) {
+				return result;
+			}
+
+			while (cursor.moveToNext()) {
+				Link link = new Link();
+				link.setId(cursor.getLong(cursor
+						.getColumnIndex(LinksTable.KEY_ROWID)));
+				link.setName(cursor.getString(cursor
+						.getColumnIndex(LinksTable.KEY_LINK_NAME)));
+				link.setURL(cursor.getString(cursor
+						.getColumnIndex(LinksTable.KEY_LINK_URL)));
+
+				result.add(link);
+			}
+
+			return result;
+		} finally {
+			if (cursor != null) {
+				cursor.close();
+			}
+		}
+	}
+
+	public void deleteLink(long id) {
+		context.getContentResolver().delete(LinksTable.CONTENT_URI,
+				LinksTable.KEY_ROWID + "=" + id + "", null);
+		
+		backupManager.dataChanged();
+	}
+
+	public void addLink(String packageName, String url, String name) {
+		ContentValues values = new ContentValues();
+		values.put(LinksTable.KEY_LINK_PACKAGENAME, packageName);
+		values.put(LinksTable.KEY_LINK_URL, url);
+		values.put(LinksTable.KEY_LINK_NAME, name);
+		context.getContentResolver().insert(LinksTable.CONTENT_URI, values);
+		
+		backupManager.dataChanged();
+	}
+
+	public void editLink(Long id, String url, String name) {
+		ContentValues values = new ContentValues();
+		values.put(LinksTable.KEY_LINK_URL, url);
+		values.put(LinksTable.KEY_LINK_NAME, name);
+
+		context.getContentResolver().update(LinksTable.CONTENT_URI, values,
+				LinksTable.KEY_ROWID + " = " + id, null);
+		
+		backupManager.dataChanged();
+	}
 }

--- a/src/com/github/andlyticsproject/LinksActivity.java
+++ b/src/com/github/andlyticsproject/LinksActivity.java
@@ -1,0 +1,248 @@
+package com.github.andlyticsproject;
+
+import java.util.ArrayList;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.drawable.BitmapDrawable;
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentTransaction;
+import android.view.ContextMenu;
+import android.view.ContextMenu.ContextMenuInfo;
+import android.view.View;
+import android.widget.ListView;
+
+import com.actionbarsherlock.app.SherlockFragmentActivity;
+import com.actionbarsherlock.view.Menu;
+import com.actionbarsherlock.view.MenuItem;
+import com.github.andlyticsproject.dialog.AddEditLinkDialog;
+import com.github.andlyticsproject.model.Link;
+import com.github.andlyticsproject.util.DetachableAsyncTask;
+import com.github.andlyticsproject.util.Utils;
+
+public class LinksActivity extends SherlockFragmentActivity implements
+		AddEditLinkDialog.OnFinishAddEditLinkDialogListener {
+
+	public static final String TAG = Main.class.getSimpleName();
+
+	private LinksListAdapter linksListAdapter;
+
+	private LoadLinksDb loadLinksDb;
+
+	private ArrayList<Link> links;
+
+	private ListView list;
+
+	private View nolinks;
+
+	private ContentAdapter db;
+
+	private static final int EDIT = 1;
+	private static final int DELETE = 2;
+
+	private String packageName;
+	private String iconFilePath;
+
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		setContentView(R.layout.links);
+
+		Bundle b = getIntent().getExtras();
+		if (b != null) {
+			packageName = b.getString(Constants.PACKAGE_NAME_PARCEL);
+			iconFilePath = b.getString(Constants.ICON_FILE_PARCEL);
+		}
+
+		getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
+		String appName = getDbAdapter().getAppName(packageName);
+		if (appName != null) {
+			getSupportActionBar().setSubtitle(appName);
+		}
+
+		if (iconFilePath != null) {
+			Bitmap bm = BitmapFactory.decodeFile(iconFilePath);
+			BitmapDrawable icon = new BitmapDrawable(getResources(), bm);
+			getSupportActionBar().setIcon(icon);
+		}
+
+		list = (ListView) findViewById(R.id.links_list);
+
+		nolinks = findViewById(R.id.links_nolinks);
+		list.setEmptyView(nolinks);
+
+		links = new ArrayList<Link>();
+
+		linksListAdapter = new LinksListAdapter(this);
+		list.setAdapter(linksListAdapter);
+
+		linksListAdapter.setLinks(links);
+		linksListAdapter.notifyDataSetChanged();
+
+		db = getDbAdapter();
+
+		loadLinksDb = new LoadLinksDb(this);
+		Utils.execute(loadLinksDb);
+
+		registerForContextMenu(list);
+	}
+
+	@Override
+	public void onCreateContextMenu(ContextMenu menu, View v,
+			ContextMenuInfo menuInfo) {
+		super.onCreateContextMenu(menu, v, menuInfo);
+		menu.add(0, EDIT, 0, R.string.edit);
+		menu.add(0, DELETE, 0, R.string.delete);
+	}
+
+	@Override
+	public boolean onContextItemSelected(android.view.MenuItem item) {
+		switch (item.getItemId()) {
+		case EDIT:
+			android.widget.AdapterView.AdapterContextMenuInfo menuInfo = (android.widget.AdapterView.AdapterContextMenuInfo) item
+					.getMenuInfo();
+
+			int position = menuInfo.position;
+			Link link = links.get(position);
+
+			showAddEditLinkDialog(link);
+			return true;
+		case DELETE:
+			menuInfo = (android.widget.AdapterView.AdapterContextMenuInfo) item
+					.getMenuInfo();
+
+			position = menuInfo.position;
+			link = links.get(position);
+
+			db.deleteLink(link.getId().longValue());
+
+			loadLinksDb = new LoadLinksDb(this);
+			Utils.execute(loadLinksDb);
+
+			return true;
+		}
+		return super.onContextItemSelected(item);
+	}
+
+	@Override
+	public boolean onCreateOptionsMenu(Menu menu) {
+		menu.clear();
+		getSupportMenuInflater().inflate(R.menu.links_menu, menu);
+
+		return true;
+	}
+
+	/**
+	 * Called if item in option menu is selected.
+	 * 
+	 * @param item
+	 *            The chosen menu item
+	 * @return boolean true/false
+	 */
+	@Override
+	public boolean onOptionsItemSelected(MenuItem item) {
+		switch (item.getItemId()) {
+		case android.R.id.home:
+			finish();
+			overridePendingTransition(R.anim.activity_prev_in,
+					R.anim.activity_prev_out);
+			return true;
+		case R.id.itemLinksmenuAdd:
+			showAddEditLinkDialog(null);
+			return true;
+		default:
+			return (super.onOptionsItemSelected(item));
+		}
+	}
+
+	@Override
+	public void onBackPressed() {
+		finish();
+		overridePendingTransition(R.anim.activity_prev_in, R.anim.activity_prev_out);
+	}
+	
+	public ContentAdapter getDbAdapter() {
+		return getAndlyticsApplication().getDbAdapter();
+	}
+
+	public AndlyticsApp getAndlyticsApplication() {
+		return (AndlyticsApp) getApplication();
+	}
+
+	private static class LoadLinksDb extends
+			DetachableAsyncTask<Void, Void, Void, LinksActivity> {
+
+		LoadLinksDb(LinksActivity activity) {
+			super(activity);
+		}
+
+		@Override
+		protected Void doInBackground(Void... params) {
+			if (activity == null) {
+				return null;
+			}
+
+			activity.getLinksFromDb();
+
+			return null;
+		}
+
+		@Override
+		protected void onPostExecute(Void result) {
+			if (activity == null) {
+				return;
+			}
+
+			activity.refreshLinks();
+		}
+
+	}
+
+	private void getLinksFromDb() {
+		links = db.getLinksByPackageName(packageName);
+	}
+
+	private void refreshLinks() {
+		linksListAdapter.setLinks(links);
+		linksListAdapter.notifyDataSetChanged();
+	}
+
+	@Override
+	public void onFinishAddEditLink(String url, String name, Long id) {
+		if (id == null) {
+			db.addLink(packageName, url, name);
+		} else {
+			db.editLink(id, url, name);
+		}
+
+		loadLinksDb = new LoadLinksDb(this);
+		Utils.execute(loadLinksDb);
+	}
+
+	private void showAddEditLinkDialog(Link link) {
+		FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
+		Fragment prev = getSupportFragmentManager().findFragmentByTag(
+				"fragment_addedit_link");
+		if (prev != null) {
+			ft.remove(prev);
+		}
+		ft.addToBackStack(null);
+		AddEditLinkDialog addEditLinkDialog = new AddEditLinkDialog();
+
+		Bundle arguments = new Bundle();
+		if (link != null) {
+			arguments.putLong("id", link.getId().longValue());
+			arguments.putString("name", link.getName());
+			arguments.putString("url", link.getURL());
+		}
+		
+		arguments.putString("packageName", packageName);
+
+		addEditLinkDialog.setArguments(arguments);
+
+		addEditLinkDialog.setOnFinishAddEditLinkDialogListener(this);
+		
+		addEditLinkDialog.show(ft, "fragment_addedit_link");
+	}
+}

--- a/src/com/github/andlyticsproject/LinksListAdapter.java
+++ b/src/com/github/andlyticsproject/LinksListAdapter.java
@@ -1,0 +1,71 @@
+package com.github.andlyticsproject;
+
+import java.util.ArrayList;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.TextView;
+
+import com.github.andlyticsproject.model.Link;
+
+public class LinksListAdapter extends BaseAdapter {
+
+	private LayoutInflater layoutInflater;
+
+	private ArrayList<Link> links;
+
+	public LinksListAdapter(LinksActivity activity) {
+		this.layoutInflater = activity.getLayoutInflater();
+		this.links = new ArrayList<Link>();
+	}
+
+	@Override
+	public View getView(int position, View convertView, ViewGroup parent) {
+
+		final Link link = getItem(position);
+		ViewHolderChild holder;
+
+		if (convertView == null) {
+			convertView = layoutInflater.inflate(R.layout.links_list_item, null);
+
+			holder = new ViewHolderChild();
+			holder.name = (TextView) convertView.findViewById(R.id.links_list_item_name);
+			holder.url = (TextView) convertView.findViewById(R.id.links_list_item_url);
+
+			convertView.setTag(holder);
+		} else {
+			holder = (ViewHolderChild) convertView.getTag();
+		}
+		
+		holder.name.setText(link.getName());
+		holder.url.setText(link.getURL());
+
+		return convertView;
+	}
+
+	static class ViewHolderChild {
+		TextView name;
+		TextView url;
+	}
+	
+	public void setLinks(ArrayList<Link> links) {
+		this.links = links;
+	}
+
+	@Override
+	public int getCount() {
+		return links.size();
+	}
+
+	@Override
+	public Link getItem(int position) {
+		return links.get(position);
+	}
+
+	@Override
+	public long getItemId(int position) {
+		return links.get(position).getId().longValue();
+	}
+}

--- a/src/com/github/andlyticsproject/MainListAdapter.java
+++ b/src/com/github/andlyticsproject/MainListAdapter.java
@@ -323,6 +323,22 @@ public class MainListAdapter extends BaseAdapter {
 		}
 
 		holder.icon.setTag(TAG_IMAGE_REF, packageName);
+		
+		holder.icon.setOnClickListener(new OnClickListener() {
+			@Override
+			public void onClick(View v) {
+				Intent intent = new Intent(activity, LinksActivity.class);
+				intent.putExtra(Constants.PACKAGE_NAME_PARCEL, packageName);
+				if (iconFile.exists()) {
+					intent.putExtra(Constants.ICON_FILE_PARCEL, iconFile.getAbsolutePath());
+				}
+				
+				activity.startActivity(intent);
+				activity.overridePendingTransition(R.anim.activity_next_in,
+						R.anim.activity_next_out);
+			}
+		});
+		
 		holder.row.setOnClickListener(new OnClickListener() {
 
 			@Override

--- a/src/com/github/andlyticsproject/db/AndlyticsContentProvider.java
+++ b/src/com/github/andlyticsproject/db/AndlyticsContentProvider.java
@@ -24,6 +24,7 @@ public class AndlyticsContentProvider extends ContentProvider {
 	private static final int ID_TABLE_ADMOB = 3;
 	private static final int ID_APP_VERSION_CHANGE = 4;
 	private static final int ID_UNIQUE_PACKAGES = 5;
+	private static final int ID_TABLE_LINKS = 6;
 
 	public static final String AUTHORITY = "com.github.andlyticsproject.db.AndlyticsContentProvider";
 
@@ -50,6 +51,9 @@ public class AndlyticsContentProvider extends ContentProvider {
 		case ID_TABLE_ADMOB:
 			count = db.delete(AdmobTable.DATABASE_TABLE_NAME, where, whereArgs);
 			break;
+		case ID_TABLE_LINKS:
+			count = db.delete(LinksTable.DATABASE_TABLE_NAME, where, whereArgs);
+			break;
 
 		default:
 			throw new IllegalArgumentException("Unknown URI " + uri);
@@ -72,6 +76,8 @@ public class AndlyticsContentProvider extends ContentProvider {
 			return AdmobTable.CONTENT_TYPE;
 		case ID_APP_VERSION_CHANGE:
 			return APP_VERSION_CHANGE;
+		case ID_TABLE_LINKS:
+			return LinksTable.CONTENT_TYPE;
 
 		default:
 			throw new IllegalArgumentException("Unknown URI " + uri);
@@ -156,6 +162,16 @@ public class AndlyticsContentProvider extends ContentProvider {
 				getContext().getContentResolver().notifyChange(noteUri, null);
 				return noteUri;
 			}
+		
+		case ID_TABLE_LINKS:
+
+			rowId = db.insert(LinksTable.DATABASE_TABLE_NAME, null, values);
+			if (rowId > 0) {
+				Uri noteUri = ContentUris.withAppendedId(LinksTable.CONTENT_URI, rowId);
+				getContext().getContentResolver().notifyChange(noteUri, null);
+				return noteUri;
+			}
+			
 		}
 
 		throw new SQLException("Failed to insert row into " + uri);
@@ -188,6 +204,10 @@ public class AndlyticsContentProvider extends ContentProvider {
 		case ID_TABLE_COMMENTS:
 			qb.setTables(CommentsTable.DATABASE_TABLE_NAME);
 			qb.setProjectionMap(CommentsTable.PROJECTION_MAP);
+			break;
+		case ID_TABLE_LINKS:
+			qb.setTables(LinksTable.DATABASE_TABLE_NAME);
+			qb.setProjectionMap(LinksTable.PROJECTION_MAP);
 			break;
 		case ID_TABLE_ADMOB:
 			qb.setTables(AdmobTable.DATABASE_TABLE_NAME);
@@ -247,6 +267,9 @@ public class AndlyticsContentProvider extends ContentProvider {
 		case ID_TABLE_COMMENTS:
 			count = db.update(CommentsTable.DATABASE_TABLE_NAME, values, where, whereArgs);
 			break;
+		case ID_TABLE_LINKS:
+			count = db.update(LinksTable.DATABASE_TABLE_NAME, values, where, whereArgs);
+			break;
 		case ID_TABLE_ADMOB:
 			count = db.update(AdmobTable.DATABASE_TABLE_NAME, values, where, whereArgs);
 			break;
@@ -265,6 +288,7 @@ public class AndlyticsContentProvider extends ContentProvider {
 		sUriMatcher.addURI(AUTHORITY, AppInfoTable.DATABASE_TABLE_NAME, ID_TABLE_APPINFO);
 		sUriMatcher.addURI(AUTHORITY, AppInfoTable.UNIQUE_PACKAGE_NAMES, ID_UNIQUE_PACKAGES);
 		sUriMatcher.addURI(AUTHORITY, CommentsTable.DATABASE_TABLE_NAME, ID_TABLE_COMMENTS);
+		sUriMatcher.addURI(AUTHORITY, LinksTable.DATABASE_TABLE_NAME, ID_TABLE_LINKS);
 		sUriMatcher.addURI(AUTHORITY, AdmobTable.DATABASE_TABLE_NAME, ID_TABLE_ADMOB);
 		sUriMatcher.addURI(AUTHORITY, APP_VERSION_CHANGE, ID_APP_VERSION_CHANGE);
 

--- a/src/com/github/andlyticsproject/db/AndlyticsDb.java
+++ b/src/com/github/andlyticsproject/db/AndlyticsDb.java
@@ -21,7 +21,7 @@ public class AndlyticsDb extends SQLiteOpenHelper {
 
 	private static final String TAG = AndlyticsDb.class.getSimpleName();
 
-	private static final int DATABASE_VERSION = 19;
+	private static final int DATABASE_VERSION = 20;
 
 	private static final String DATABASE_NAME = "andlytics";
 
@@ -50,6 +50,7 @@ public class AndlyticsDb extends SQLiteOpenHelper {
 		db.execSQL(CommentsTable.TABLE_CREATE_COMMENTS);
 		db.execSQL(AdmobTable.TABLE_CREATE_ADMOB);
 		db.execSQL(DeveloperAccountsTable.TABLE_CREATE_DEVELOPER_ACCOUNT);
+		db.execSQL(LinksTable.TABLE_CREATE_LINKS);
 	}
 
 	@Override
@@ -133,6 +134,13 @@ public class AndlyticsDb extends SQLiteOpenHelper {
 			Log.d(TAG, "Old version < 19 - adding new appstats columns");
 			db.execSQL("ALTER table " + AppStatsTable.DATABASE_TABLE_NAME + " add "
 					+ AppStatsTable.KEY_STATS_NUM_ERRORS + " integer");
+		}
+		
+		if (oldVersion < 20) {
+			Log.w(TAG, "Old version < 20 - adding links table");
+			
+			db.execSQL("DROP TABLE IF EXISTS " + LinksTable.DATABASE_TABLE_NAME);
+			db.execSQL(LinksTable.TABLE_CREATE_LINKS);
 		}
 
 	}

--- a/src/com/github/andlyticsproject/db/LinksTable.java
+++ b/src/com/github/andlyticsproject/db/LinksTable.java
@@ -1,0 +1,40 @@
+
+package com.github.andlyticsproject.db;
+
+import android.net.Uri;
+
+import java.util.HashMap;
+
+public class LinksTable {
+
+	public static final String DATABASE_TABLE_NAME = "links";
+
+	public static final Uri CONTENT_URI = Uri.parse("content://"
+			+ AndlyticsContentProvider.AUTHORITY + "/" + DATABASE_TABLE_NAME);
+
+	public static final String CONTENT_TYPE = "vnd.android.cursor.dir/vnd.andlytics."
+			+ DATABASE_TABLE_NAME;
+
+	public static final String KEY_ROWID = "_id";
+	public static final String KEY_LINK_PACKAGENAME = "packagename";
+	public static final String KEY_LINK_NAME = "name";
+	public static final String KEY_LINK_URL = "url";
+
+	public static final String TABLE_CREATE_LINKS = "create table " + DATABASE_TABLE_NAME
+			+ " (_id integer primary key autoincrement, " + KEY_LINK_PACKAGENAME
+			+ " text not null," + KEY_LINK_NAME + " text not null," + KEY_LINK_URL
+			+ " text)";
+
+	public static HashMap<String, String> PROJECTION_MAP;
+
+	static {
+		PROJECTION_MAP = new HashMap<String, String>();
+
+		PROJECTION_MAP.put(LinksTable.KEY_ROWID, LinksTable.KEY_ROWID);
+		PROJECTION_MAP.put(LinksTable.KEY_LINK_PACKAGENAME,
+				LinksTable.KEY_LINK_PACKAGENAME);
+		PROJECTION_MAP.put(LinksTable.KEY_LINK_NAME, LinksTable.KEY_LINK_NAME);
+		PROJECTION_MAP.put(LinksTable.KEY_LINK_URL, LinksTable.KEY_LINK_URL);
+	}
+
+}

--- a/src/com/github/andlyticsproject/dialog/AddEditLinkDialog.java
+++ b/src/com/github/andlyticsproject/dialog/AddEditLinkDialog.java
@@ -1,0 +1,127 @@
+package com.github.andlyticsproject.dialog;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import android.os.Bundle;
+import android.support.v4.app.DialogFragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.view.ViewGroup;
+import android.widget.EditText;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.actionbarsherlock.app.SherlockDialogFragment;
+import com.github.andlyticsproject.R;
+
+public class AddEditLinkDialog extends SherlockDialogFragment {
+	private EditText urlInput;
+	private EditText nameInput;
+
+	private Long id = null;
+	private String name = null;
+	private String url = null;
+	private String packageName = null;
+
+	private OnFinishAddEditLinkDialogListener onFinishAddEditLinkDialogListener;
+
+	public interface OnFinishAddEditLinkDialogListener {
+		void onFinishAddEditLink(String url, String name, Long id);
+	}
+
+	public AddEditLinkDialog() {
+		setStyle(DialogFragment.STYLE_NO_FRAME, R.style.Dialog);
+	}
+
+	@Override
+	public View onCreateView(LayoutInflater inflater, ViewGroup container,
+			Bundle savedInstanceState) {
+		Bundle arguments = getArguments();
+
+		View view = inflater.inflate(R.layout.links_addedit_dialog, container);
+
+		if (arguments.containsKey("id")) {
+			id = Long.valueOf(arguments.getLong("id"));
+			name = arguments.getString("name");
+			url = arguments.getString("url");
+		}
+
+		packageName = arguments.getString("packageName");
+
+		if (id != null) {
+			TextView title = (TextView) view
+					.findViewById(R.id.links_addedit_dialog_title);
+			title.setText(R.string.links_addedit_dialog_title_edit);
+		}
+
+		urlInput = (EditText) view
+				.findViewById(R.id.links_addedit_dialog_url_input);
+		nameInput = (EditText) view
+				.findViewById(R.id.links_addedit_dialog_name_input);
+
+		if (url != null) {
+			urlInput.setText(url);
+		}
+
+		if (name != null) {
+			nameInput.setText(name);
+		}
+
+		view.findViewById(R.id.links_addedit_dialog_positive_button)
+				.setOnClickListener(new OnClickListener() {
+					public void onClick(View v) {
+						String urlString = urlInput.getText().toString();
+						String nameString = nameInput.getText().toString();
+
+						urlString = urlString.toString();
+
+						try {
+							URL url = new URL(urlString);
+							urlString = url.toString();
+
+							if (nameString.trim().length() == 0) {
+								nameString = url.getHost();
+							}
+
+							onFinishAddEditLinkDialogListener
+									.onFinishAddEditLink(urlString, nameString,
+											id);
+							dismiss();
+						} catch (MalformedURLException e) {
+							Toast.makeText(
+									AddEditLinkDialog.this.getActivity(),
+									getString(R.string.links_addedit_dialog_not_url),
+									Toast.LENGTH_LONG).show();
+						}
+					}
+				});
+
+		view.findViewById(R.id.links_addedit_dialog_negative_button)
+				.setOnClickListener(new OnClickListener() {
+					public void onClick(View v) {
+						dismiss();
+					}
+				});
+
+		view.findViewById(R.id.links_addedit_dialog_url_marketbutton)
+				.setOnClickListener(new OnClickListener() {
+					public void onClick(View v) {
+						/**
+						 * market:// links can't be made automatically
+						 * clickable. This was the easier solution.
+						 */
+						urlInput.setText("http://play.google.com/store/apps/details?id="
+								+ packageName);
+					}
+				});
+
+		return view;
+	}
+
+	public void setOnFinishAddEditLinkDialogListener(
+			OnFinishAddEditLinkDialogListener listener) {
+		onFinishAddEditLinkDialogListener = listener;
+	}
+}

--- a/src/com/github/andlyticsproject/model/Link.java
+++ b/src/com/github/andlyticsproject/model/Link.java
@@ -1,0 +1,34 @@
+package com.github.andlyticsproject.model;
+
+public class Link {
+	
+	public Long id;
+	
+	private String name;
+	
+	private String url;
+	
+	public Long getId() {
+		return id;
+	}
+	
+	public void setId(Long id) {
+		this.id = id;
+	}
+	
+	public String getName() {
+		return name;
+	}
+	
+	public void setName(String name) {
+		this.name = name;
+	}
+	
+	public String getURL() {
+		return url;
+	}
+	
+	public void setURL(String url) {
+		this.url = url;
+	}
+}


### PR DESCRIPTION
I was looking for a way to link from Andlytics to the Google Play store so I could monitor things not tracked in the app -- like the "more by" and "also viewed" links, the G+1 counter, etc.

Then I realized that I look at a lot more than just the Play store: Amazon's web store stats, Flurry stats, Google+/Facebook pages dedicated to the app, and so on.

So, I added a new "links" feature for Andlytics. This feature allows you to add arbitrary URLs to list of links associated with an app. You can reach the links page by tapping the app's icon on the main screen.

This is my first contribution to Andlytics; please let me know if I should have handled this differently.
