### PR TITLE
quick hack to display translated comments

### DIFF
--- a/src/com/github/andlyticsproject/CommentsActivity.java
+++ b/src/com/github/andlyticsproject/CommentsActivity.java
@@ -288,9 +288,8 @@ public class CommentsActivity extends BaseDetailsActivity {
 			if (activity.maxAvailableComments != 0) {
 				DevConsoleV2 console = DevConsoleRegistry.getInstance().get(activity.accountName);
 				try {
-
 					List<Comment> result = console.getComments(activity, activity.packageName,
-							activity.nextCommentIndex, MAX_LOAD_COMMENTS);
+							activity.nextCommentIndex, MAX_LOAD_COMMENTS, Utils.getDisplayLocale());
 					activity.updateCommentsCacheIfNecessary(result);
 
 					activity.incrementNextCommentIndex(result.size());
@@ -386,7 +385,8 @@ public class CommentsActivity extends BaseDetailsActivity {
 			if (prevComment != null) {
 
 				CommentGroup group = new CommentGroup();
-				group.setDate(comment.isReply() ? comment.getOriginalCommentDate() : comment.getDate());
+				group.setDate(comment.isReply() ? comment.getOriginalCommentDate() : comment
+						.getDate());
 
 				if (commentGroups.contains(group)) {
 

--- a/src/com/github/andlyticsproject/CommentsListAdapter.java
+++ b/src/com/github/andlyticsproject/CommentsListAdapter.java
@@ -77,19 +77,26 @@ public class CommentsListAdapter extends BaseExpandableListAdapter {
 		} else {
 			holder = (ViewHolderChild) convertView.getTag();
 		}
-		
+
 		if (comment.isReply()) {
 			holder.date.setText(formatCommentDate(comment.getDate()));
 			holder.text.setText(comment.getText());
 		} else {
-			String[] commentContent = comment.getText().split("\t");
+			String[] commentContent = comment.getText().split("\\t");
 			if (commentContent != null && commentContent.length > 1) {
 				holder.title.setText(commentContent[0]);
-				holder.text.setText(commentContent[1]);
+				// TODO better UI, persist language
+				holder.text.setText(commentContent[1]
+						+ (comment.getLanguage() == null ? "" : String.format(" [%s]",
+								comment.getLanguage())));
 				holder.text.setVisibility(View.VISIBLE);
-			} else if(commentContent != null && commentContent.length == 1) {
-				holder.title.setText(commentContent[0]);
-				holder.text.setVisibility(View.GONE);		
+			} else if (commentContent != null && commentContent.length == 1) {
+				// TODO better UI, persist language
+				holder.text.setText(commentContent[0]
+						+ (comment.getLanguage() == null ? "" : String.format(" [%s]",
+								comment.getLanguage())));
+				holder.title.setText(null);
+				holder.title.setVisibility(View.GONE);
 			}
 			holder.user.setText(comment.getUser() == null ? context
 					.getString(R.string.comment_no_user_info) : comment.getUser());
@@ -100,21 +107,21 @@ public class CommentsListAdapter extends BaseExpandableListAdapter {
 			holder.version.setVisibility(View.GONE);
 			holder.device.setVisibility(View.GONE);
 			boolean showInfoBox = false;
-			
+
 			// building version/device
 			if (isNotEmptyOrNull(version)) {
 				holder.version.setText(version);
 				holder.versionIcon.setVisibility(View.VISIBLE);
 				holder.version.setVisibility(View.VISIBLE);
 				showInfoBox = true;
-			} 
+			}
 			if (isNotEmptyOrNull(device)) {
 				holder.device.setText(device);
 				holder.deviceIcon.setVisibility(View.VISIBLE);
 				holder.device.setVisibility(View.VISIBLE);
 				showInfoBox = true;
 			}
-			
+
 			if (showInfoBox) {
 				holder.deviceVersionContainer.setVisibility(View.VISIBLE);
 			} else {
@@ -220,7 +227,7 @@ public class CommentsListAdapter extends BaseExpandableListAdapter {
 	static class ViewHolderChild {
 		RatingBar rating;
 		TextView text;
-		TextView title;		
+		TextView title;
 		TextView user;
 		TextView date;
 		LinearLayout deviceVersionContainer;

--- a/src/com/github/andlyticsproject/console/DevConsole.java
+++ b/src/com/github/andlyticsproject/console/DevConsole.java
@@ -14,7 +14,7 @@ public interface DevConsole {
 	// pass null when calling from a service
 	List<AppInfo> getAppInfo(Activity activity) throws DevConsoleException;
 
-	List<Comment> getComments(Activity activity, String packageName, int startIndex, int count)
-			throws DevConsoleException;
+	List<Comment> getComments(Activity activity, String packageName, int startIndex, int count,
+			String displayLocale) throws DevConsoleException;
 
 }

--- a/src/com/github/andlyticsproject/console/v2/DevConsoleV2Protocol.java
+++ b/src/com/github/andlyticsproject/console/v2/DevConsoleV2Protocol.java
@@ -34,9 +34,9 @@ public class DevConsoleV2Protocol {
 	// 1$: package name, 2$: XSRF
 	static final String GET_RATINGS_TEMPLATE = "{\"method\":\"getRatings\","
 			+ "\"params\":{\"1\":[\"%1$s\"]},\"xsrf\":\"%2$s\"}";
-	// 1$: package name, 2$: start, 3$: num comments to fetch, 4$ XSRF
+	// 1$: package name, 2$: start, 3$: num comments to fetch, 4$: display locale, 5$ XSRF
 	static final String GET_REVIEWS_TEMPLATE = "{\"method\":\"getReviews\","
-			+ "\"params\":{\"1\":\"%1$s\",\"2\":%2$d,\"3\":%3$d},\"xsrf\":\"%4$s\"}";
+			+ "\"params\":{\"1\":\"%1$s\",\"2\":%2$d,\"3\":%3$d,\"8\":%4$s},\"xsrf\":\"%5$s\"}";
 	// 1$: package name, 2$: stats type, 3$: stats by, 4$: XSRF
 	static final String GET_COMBINED_STATS_TEMPLATE = "{\"method\":\"getCombinedStats\","
 			+ "\"params\":{\"1\":\"%1$s\",\"2\":1,\"3\":%2$d,\"4\":[%3$d]},\"xsrf\":\"%4$s\"}";
@@ -197,10 +197,11 @@ public class DevConsoleV2Protocol {
 		}
 	}
 
-	String createFetchCommentsRequest(String packageName, int start, int pageSize) {
+	String createFetchCommentsRequest(String packageName, int start, int pageSize,
+			String displayLocale) {
 		checkState();
 
-		return String.format(GET_REVIEWS_TEMPLATE, packageName, start, pageSize,
+		return String.format(GET_REVIEWS_TEMPLATE, packageName, start, pageSize, displayLocale,
 				sessionCredentials.getXsrfToken());
 	}
 

--- a/src/com/github/andlyticsproject/console/v2/JsonParser.java
+++ b/src/com/github/andlyticsproject/console/v2/JsonParser.java
@@ -3,6 +3,7 @@ package com.github.andlyticsproject.console.v2;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -436,7 +437,24 @@ public class JsonParser {
 			if (version != null && !"".equals(version) && !version.equals("null")) {
 				comment.setAppVersion(version);
 			}
-			comment.setText(jsonComment.optJSONObject("5").getString("3"));
+
+			String commentLang = jsonComment.optJSONObject("5").getString("1");
+			String commentText = jsonComment.optJSONObject("5").getString("3");
+			comment.setLanguage(commentLang);
+			comment.setOriginalText(commentText);
+			// overwritten if translation is available
+			comment.setText(commentText);
+
+			JSONObject translation = jsonComment.optJSONObject("11");
+			if (translation != null) {
+				String displayLanguage = Locale.getDefault().getLanguage();
+				String translationLang = translation.getString("1");
+				String translationText = translation.getString("3");
+				if (translationLang.contains(displayLanguage)) {
+					comment.setText(translationText);
+				}
+			}
+
 			JSONObject jsonDevice = jsonComment.optJSONObject("8");
 			if (jsonDevice != null) {
 				String device = jsonDevice.optString("3");

--- a/src/com/github/andlyticsproject/model/Comment.java
+++ b/src/com/github/andlyticsproject/model/Comment.java
@@ -9,7 +9,14 @@ public class Comment {
 	
 	private boolean isReply = false;
 
+	// this is the translated text
 	private String text;
+
+	// no persisted for now
+	private String originalText;
+
+	// language of the orignal comment
+	private String language;
 
 	private Date date;
 	
@@ -39,6 +46,22 @@ public class Comment {
 
 	public void setText(String text) {
 		this.text = text;
+	}
+
+	public String getOriginalText() {
+		return originalText;
+	}
+
+	public void setOriginalText(String originalText) {
+		this.originalText = originalText;
+	}
+
+	public String getLanguage() {
+		return language;
+	}
+
+	public void setLanguage(String language) {
+		this.language = language;
 	}
 
 	/**

--- a/src/com/github/andlyticsproject/util/Utils.java
+++ b/src/com/github/andlyticsproject/util/Utils.java
@@ -8,6 +8,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Locale;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
@@ -166,6 +167,12 @@ public final class Utils {
 		} catch (PackageManager.NameNotFoundException e) {
 			return false;
 		}
+	}
+
+	// the console uses the 'en-US' format
+	public static String getDisplayLocale() {
+		return String.format("%s-%s", Locale.getDefault().getLanguage(), Locale.getDefault()
+				.getCountry());
 	}
 
 }


### PR DESCRIPTION
Needs more work: 
- persist comment language
- decide whether to persist original comment or translated text (right now translation)
- detect locale changes and invalidate comment cache (see above, right now you get cached values which may be different from the current locale; need to refresh manually)
- better UI
- maybe add an option to display original comment
