### PR TITLE
don't explictly check for AD cookie, it's not used anymore

### DIFF
--- a/src/com/github/andlyticsproject/console/v2/AccountManagerAuthenticator.java
+++ b/src/com/github/andlyticsproject/console/v2/AccountManagerAuthenticator.java
@@ -6,9 +6,7 @@ import java.util.List;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
-import org.apache.http.client.CookieStore;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.cookie.Cookie;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.util.EntityUtils;
 
@@ -173,18 +171,6 @@ public class AccountManagerAuthenticator extends BaseAuthenticator {
 				Log.d(TAG, "Response: " + responseStr);
 			}
 
-			CookieStore cookieStore = httpClient.getCookieStore();
-			List<Cookie> cookies = cookieStore.getCookies();
-			String adCookie = findAdCookie(cookies);
-			if (DEBUG) {
-				Log.d(TAG, "AD cookie " + adCookie);
-			}
-			if (adCookie == null) {
-				debugAuthFailure(activity, responseStr);
-
-				throw new AuthenticationException("Couldn't get AD cookie.");
-			}
-
 			DeveloperConsoleAccount[] developerAccounts = findDeveloperAccounts(responseStr);
 			if (developerAccounts == null) {
 				debugAuthFailure(activity, responseStr);
@@ -203,7 +189,7 @@ public class AccountManagerAuthenticator extends BaseAuthenticator {
 
 			SessionCredentials result = new SessionCredentials(accountName, xsrfToken,
 					developerAccounts);
-			result.addCookies(cookies);
+			result.addCookies(httpClient.getCookieStore().getCookies());
 			result.addWhitelistedFeatures(whitelistedFeatures);
 
 			return result;

--- a/src/com/github/andlyticsproject/console/v2/BaseAuthenticator.java
+++ b/src/com/github/andlyticsproject/console/v2/BaseAuthenticator.java
@@ -7,7 +7,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringEscapeUtils;
-import org.apache.http.cookie.Cookie;
 
 import com.github.andlyticsproject.model.DeveloperConsoleAccount;
 
@@ -27,15 +26,6 @@ public abstract class BaseAuthenticator implements DevConsoleAuthenticator {
 
 	protected BaseAuthenticator(String accountName) {
 		this.accountName = accountName;
-	}
-
-	protected String findAdCookie(List<Cookie> cookies) {
-		for (Cookie c : cookies) {
-			if ("AD".equals(c.getName())) {
-				return c.getValue();
-			}
-		}
-		return null;
 	}
 
 	protected String findXsrfToken(String responseStr) {

--- a/src/com/github/andlyticsproject/console/v2/PasswordAuthenticator.java
+++ b/src/com/github/andlyticsproject/console/v2/PasswordAuthenticator.java
@@ -90,15 +90,6 @@ public class PasswordAuthenticator extends BaseAuthenticator {
 				throw new AuthenticationException("Auth error: " + response.getStatusLine());
 			}
 
-			cookies = cookieStore.getCookies();
-			String adCookie = findAdCookie(cookies);
-			if (DEBUG) {
-				Log.d(TAG, "AD cookie " + adCookie);
-			}
-			if (adCookie == null) {
-				throw new AuthenticationException("Couldn't get AD cookie.");
-			}
-
 			String responseStr = EntityUtils.toString(response.getEntity());
 			if (DEBUG) {
 				Log.d(TAG, "Response: " + responseStr);
@@ -117,7 +108,7 @@ public class PasswordAuthenticator extends BaseAuthenticator {
 
 			SessionCredentials result = new SessionCredentials(accountName, xsrfToken,
 					developerAccounts);
-			result.addCookies(cookies);
+			result.addCookies(cookieStore.getCookies());
 			result.addWhitelistedFeatures(whitelistedFeatures);
 
 			return result;


### PR DESCRIPTION
HttpClient is sending all cookies anyway, no reason to depend on the actual cookie names, etc.
