### PR TITLE
Small inconsistency: Removed generic Intent i and moved dependencies to ...

### DIFF
--- a/src/com/github/andlyticsproject/Main.java
+++ b/src/com/github/andlyticsproject/Main.java
@@ -236,7 +236,6 @@ public class Main extends BaseActivity implements OnNavigationListener {
 	 */
 	@Override
 	public boolean onOptionsItemSelected(MenuItem item) {
-		Intent i = null;
 		switch (item.getItemId()) {
 		case R.id.itemMainmenuRefresh:
 			loadRemoteEntries();
@@ -267,9 +266,9 @@ public class Main extends BaseActivity implements OnNavigationListener {
 			//showDialog(DIALOG_ABOUT_ID);
 			break;
 		case R.id.itemMainmenuPreferences:
-			i = new Intent(this, PreferenceActivity.class);
-			i.putExtra(Constants.AUTH_ACCOUNT_NAME, accountName);
-			startActivity(i);
+			Intent preferencesIntent = new Intent(this, PreferenceActivity.class);
+			preferencesIntent.putExtra(Constants.AUTH_ACCOUNT_NAME, accountName);
+			startActivity(preferencesIntent);
 			break;
 		case R.id.itemMainmenuStatsMode:
 			if (currentStatsMode.equals(StatsMode.PERCENT)) {
@@ -280,9 +279,9 @@ public class Main extends BaseActivity implements OnNavigationListener {
 			updateStatsMode();
 			break;
 		case R.id.itemMainmenuAccounts:
-			i = new Intent(this, LoginActivity.class);
-			i.putExtra(Constants.MANAGE_ACCOUNTS_MODE, true);
-			startActivityForResult(i, REQUEST_CODE_MANAGE_ACCOUNTS);
+			Intent accountsIntent = new Intent(this, LoginActivity.class);
+			accountsIntent.putExtra(Constants.MANAGE_ACCOUNTS_MODE, true);
+			startActivityForResult(accountsIntent, REQUEST_CODE_MANAGE_ACCOUNTS);
 			break;
 		default:
 			return false;


### PR DESCRIPTION
......

As commented by : @nelenkov on prior patch: https://github.com/AndlyticsProject/andlytics/pull/480
"Looks good, but can you please make this against the dev branch? We try not to touch master unless something in the API breaks. It will be merged into master in the next release."

As commented by : @nelenkov on prior patch: https://github.com/AndlyticsProject/andlytics/pull/479
"Thanks for the patch. However, I don't think this makes it more readable. Getting rid of the Intent i would be better IMHO. It's not like the switch just sets up the intent and it is started at the end of the method -- some cases use startActivity() and others startActivityForResult() so it is better each case to use an explicit, named intent."
