### PR TITLE
Fixed comment parsing, added comment titles

### DIFF
--- a/src/com/github/andlyticsproject/CommentsListAdapter.java
+++ b/src/com/github/andlyticsproject/CommentsListAdapter.java
@@ -123,28 +123,17 @@ public class CommentsListAdapter extends BaseExpandableListAdapter {
 		} else {
 			boolean showTranslations = Preferences.isShowCommentAutoTranslations(context);
 			String commentText = comment.getText();
+			String commentTitle = comment.getTitle();
 			if (!showTranslations && comment.getOriginalText() != null) {
 				commentText = comment.getOriginalText();
 			}
-
-			// XXX translations replace the tab delimiter with space, so
-			// no way to separate the title. Show title in original language
-			// for now
-			String originalTitleAndComment[] = comment.getOriginalText() == null ? null : comment
-					.getOriginalText().split("\\t");
-			if (originalTitleAndComment != null && originalTitleAndComment.length > 1) {
-				holder.title.setText(originalTitleAndComment[0]);
-				if (showTranslations) {
-					holder.text.setText(commentText);
-				} else {
-					holder.text.setText(originalTitleAndComment[1]);
-				}
-				holder.text.setVisibility(View.VISIBLE);
-			} else {
-				holder.text.setText(commentText);
-				holder.title.setText(null);
-				holder.title.setVisibility(View.GONE);
+			if (!showTranslations && comment.getOriginalTitle() != null) {
+				commentTitle = comment.getOriginalTitle();
 			}
+			
+			holder.text.setText(commentText);
+			holder.title.setText(commentTitle);
+
 			// italic for translated text
 			boolean translated = showTranslations && comment.isTranslated();
 			holder.text.setTextAppearance(context, translated ? R.style.italicText

--- a/src/com/github/andlyticsproject/ContentAdapter.java
+++ b/src/com/github/andlyticsproject/ContentAdapter.java
@@ -949,6 +949,7 @@ public class ContentAdapter {
 			initialValues
 					.put(CommentsTable.KEY_COMMENT_DATE, Utils.formatDbDate(comment.getDate()));
 			initialValues.put(CommentsTable.KEY_COMMENT_RATING, comment.getRating());
+			initialValues.put(CommentsTable.KEY_COMMENT_TITLE, comment.getTitle());
 			initialValues.put(CommentsTable.KEY_COMMENT_TEXT, comment.getText());
 			initialValues.put(CommentsTable.KEY_COMMENT_USER, comment.getUser());
 			initialValues.put(CommentsTable.KEY_COMMENT_APP_VERSION, comment.getAppVersion());
@@ -963,6 +964,7 @@ public class ContentAdapter {
 			initialValues.put(CommentsTable.KEY_COMMENT_REPLY_TEXT, replyText);
 			initialValues.put(CommentsTable.KEY_COMMENT_REPLY_DATE, replyDate);
 			initialValues.put(CommentsTable.KEY_COMMENT_LANGUAGE, comment.getLanguage());
+			initialValues.put(CommentsTable.KEY_COMMENT_ORIGINAL_TITLE, comment.getOriginalTitle());
 			initialValues.put(CommentsTable.KEY_COMMENT_ORIGINAL_TEXT, comment.getOriginalText());
 			initialValues.put(CommentsTable.KEY_COMMENT_UNIQUE_ID, comment.getUniqueId());
 
@@ -982,12 +984,16 @@ public class ContentAdapter {
 					CommentsTable.CONTENT_URI,
 					new String[] { CommentsTable.KEY_COMMENT_DATE,
 							CommentsTable.KEY_COMMENT_PACKAGENAME,
-							CommentsTable.KEY_COMMENT_RATING, CommentsTable.KEY_COMMENT_TEXT,
-							CommentsTable.KEY_COMMENT_USER, CommentsTable.KEY_COMMENT_DEVICE,
+							CommentsTable.KEY_COMMENT_RATING, 
+							CommentsTable.KEY_COMMENT_TITLE,
+							CommentsTable.KEY_COMMENT_TEXT,
+							CommentsTable.KEY_COMMENT_USER, 
+							CommentsTable.KEY_COMMENT_DEVICE,
 							CommentsTable.KEY_COMMENT_APP_VERSION,
 							CommentsTable.KEY_COMMENT_REPLY_TEXT,
 							CommentsTable.KEY_COMMENT_REPLY_DATE,
 							CommentsTable.KEY_COMMENT_LANGUAGE,
+							CommentsTable.KEY_COMMENT_ORIGINAL_TITLE,
 							CommentsTable.KEY_COMMENT_ORIGINAL_TEXT,
 							CommentsTable.KEY_COMMENT_UNIQUE_ID },
 					AppInfoTable.KEY_APP_PACKAGENAME + " = ?", new String[] { packageName },
@@ -1003,6 +1009,8 @@ public class ContentAdapter {
 				comment.setDate(Utils.parseDbDate(dateString));
 				comment.setUser(cursor.getString(cursor
 						.getColumnIndex(CommentsTable.KEY_COMMENT_USER)));
+				comment.setTitle(cursor.getString(cursor
+						.getColumnIndex(CommentsTable.KEY_COMMENT_TITLE)));
 				comment.setText(cursor.getString(cursor
 						.getColumnIndex(CommentsTable.KEY_COMMENT_TEXT)));
 				comment.setDevice(cursor.getString(cursor
@@ -1024,6 +1032,10 @@ public class ContentAdapter {
 				int idx = cursor.getColumnIndex(CommentsTable.KEY_COMMENT_LANGUAGE);
 				if (!cursor.isNull(idx)) {
 					comment.setLanguage(cursor.getString(idx));
+				}
+				idx = cursor.getColumnIndex(CommentsTable.KEY_COMMENT_ORIGINAL_TITLE);
+				if (!cursor.isNull(idx)) {
+					comment.setOriginalTitle(cursor.getString(idx));
 				}
 				idx = cursor.getColumnIndex(CommentsTable.KEY_COMMENT_ORIGINAL_TEXT);
 				if (!cursor.isNull(idx)) {

--- a/src/com/github/andlyticsproject/console/v2/JsonParser.java
+++ b/src/com/github/andlyticsproject/console/v2/JsonParser.java
@@ -466,12 +466,22 @@ public class JsonParser {
 			comment.setOriginalText(commentText);
 			// overwritten if translation is available
 			comment.setText(commentText);
+			
+			String commentTitle = jsonComment.optJSONObject("5").getString("2");
+			comment.setOriginalTitle(commentTitle);
+			comment.setTitle(commentTitle);
 
 			JSONObject translation = jsonComment.optJSONObject("11");
 			if (translation != null) {
 				String displayLanguage = Locale.getDefault().getLanguage();
 				String translationLang = translation.getString("1");
 				
+				if(translation.has("2")) {
+					String translationTitle = translation.getString("2");
+					if (translationLang.contains(displayLanguage)) {
+						comment.setTitle(translationTitle);
+					}
+				}
 				// Apparently, a translation body is not always provided
 				// Possibly happens if the translation fails or equals the original
 				if(translation.has("3")) {

--- a/src/com/github/andlyticsproject/db/AndlyticsDb.java
+++ b/src/com/github/andlyticsproject/db/AndlyticsDb.java
@@ -27,7 +27,7 @@ public class AndlyticsDb extends SQLiteOpenHelper {
 
 	private static final String TAG = AndlyticsDb.class.getSimpleName();
 
-	private static final int DATABASE_VERSION = 23;
+	private static final int DATABASE_VERSION = 24;
 
 	private static final String DATABASE_NAME = "andlytics";
 
@@ -200,6 +200,14 @@ public class AndlyticsDb extends SQLiteOpenHelper {
 			Log.w(TAG, "Old version < 23 - adding admob.currency column");
 			db.execSQL("ALTER table " + AdmobTable.DATABASE_TABLE_NAME + " add "
 					+ AdmobTable.KEY_CURRENCY + " text");
+		}
+		
+		if (oldVersion < 24) {
+			Log.w(TAG, "Old version < 24 - adding comment.title column");
+			db.execSQL("ALTER table " + CommentsTable.DATABASE_TABLE_NAME + " add "
+					+ CommentsTable.KEY_COMMENT_TITLE + " text");
+			db.execSQL("ALTER table " + CommentsTable.DATABASE_TABLE_NAME + " add "
+					+ CommentsTable.KEY_COMMENT_ORIGINAL_TITLE + " text");
 		}
 	}
 

--- a/src/com/github/andlyticsproject/db/CommentsTable.java
+++ b/src/com/github/andlyticsproject/db/CommentsTable.java
@@ -16,6 +16,7 @@ public class CommentsTable {
 
 	public static final String KEY_ROWID = "_id";
 	public static final String KEY_COMMENT_PACKAGENAME = "packagename";
+	public static final String KEY_COMMENT_TITLE = "title";
 	public static final String KEY_COMMENT_TEXT = "text";
 	public static final String KEY_COMMENT_DATE = "date";
 	public static final String KEY_COMMENT_USER = "user";
@@ -25,6 +26,7 @@ public class CommentsTable {
 	public static final String KEY_COMMENT_REPLY_TEXT = "reply_text";
 	public static final String KEY_COMMENT_REPLY_DATE = "reply_date";
 	public static final String KEY_COMMENT_LANGUAGE = "language";
+	public static final String KEY_COMMENT_ORIGINAL_TITLE = "original_title";
 	public static final String KEY_COMMENT_ORIGINAL_TEXT = "original_text";
 	public static final String KEY_COMMENT_UNIQUE_ID = "unique_id";
 
@@ -32,9 +34,11 @@ public class CommentsTable {
 			+ " (_id integer primary key autoincrement, " + KEY_COMMENT_PACKAGENAME
 			+ " text not null," + KEY_COMMENT_DATE + " text not null," + KEY_COMMENT_USER
 			+ " text," + KEY_COMMENT_DEVICE + " text," + KEY_COMMENT_APP_VERSION + " text,"
-			+ KEY_COMMENT_TEXT + " text not null," + KEY_COMMENT_RATING + " integer,"
+			+ KEY_COMMENT_TITLE + " text not null," + KEY_COMMENT_TEXT + " text not null,"
+			+ KEY_COMMENT_RATING + " integer,"
 			+ KEY_COMMENT_REPLY_TEXT + " text," + KEY_COMMENT_REPLY_DATE + " text, "
-			+ KEY_COMMENT_LANGUAGE + " text," + KEY_COMMENT_ORIGINAL_TEXT + " text, "
+			+ KEY_COMMENT_LANGUAGE + " text," 
+			+ KEY_COMMENT_ORIGINAL_TITLE + " text, " + KEY_COMMENT_ORIGINAL_TEXT + " text, "
 			+ KEY_COMMENT_UNIQUE_ID + " text)";
 
 	public static HashMap<String, String> PROJECTION_MAP;
@@ -43,24 +47,20 @@ public class CommentsTable {
 		PROJECTION_MAP = new HashMap<String, String>();
 
 		PROJECTION_MAP.put(CommentsTable.KEY_ROWID, CommentsTable.KEY_ROWID);
-		PROJECTION_MAP.put(CommentsTable.KEY_COMMENT_PACKAGENAME,
-				CommentsTable.KEY_COMMENT_PACKAGENAME);
+		PROJECTION_MAP.put(CommentsTable.KEY_COMMENT_PACKAGENAME, CommentsTable.KEY_COMMENT_PACKAGENAME);
+		PROJECTION_MAP.put(CommentsTable.KEY_COMMENT_TITLE, CommentsTable.KEY_COMMENT_TITLE);
 		PROJECTION_MAP.put(CommentsTable.KEY_COMMENT_TEXT, CommentsTable.KEY_COMMENT_TEXT);
 		PROJECTION_MAP.put(CommentsTable.KEY_COMMENT_DATE, CommentsTable.KEY_COMMENT_DATE);
 		PROJECTION_MAP.put(CommentsTable.KEY_COMMENT_USER, CommentsTable.KEY_COMMENT_USER);
 		PROJECTION_MAP.put(CommentsTable.KEY_COMMENT_RATING, CommentsTable.KEY_COMMENT_RATING);
-		PROJECTION_MAP.put(CommentsTable.KEY_COMMENT_APP_VERSION,
-				CommentsTable.KEY_COMMENT_APP_VERSION);
+		PROJECTION_MAP.put(CommentsTable.KEY_COMMENT_APP_VERSION, CommentsTable.KEY_COMMENT_APP_VERSION);
 		PROJECTION_MAP.put(CommentsTable.KEY_COMMENT_DEVICE, CommentsTable.KEY_COMMENT_DEVICE);
-		PROJECTION_MAP.put(CommentsTable.KEY_COMMENT_REPLY_TEXT,
-				CommentsTable.KEY_COMMENT_REPLY_TEXT);
-		PROJECTION_MAP.put(CommentsTable.KEY_COMMENT_REPLY_DATE,
-				CommentsTable.KEY_COMMENT_REPLY_DATE);
+		PROJECTION_MAP.put(CommentsTable.KEY_COMMENT_REPLY_TEXT, CommentsTable.KEY_COMMENT_REPLY_TEXT);
+		PROJECTION_MAP.put(CommentsTable.KEY_COMMENT_REPLY_DATE, CommentsTable.KEY_COMMENT_REPLY_DATE);
 		PROJECTION_MAP.put(CommentsTable.KEY_COMMENT_LANGUAGE, CommentsTable.KEY_COMMENT_LANGUAGE);
-		PROJECTION_MAP.put(CommentsTable.KEY_COMMENT_ORIGINAL_TEXT,
-				CommentsTable.KEY_COMMENT_ORIGINAL_TEXT);
-		PROJECTION_MAP
-				.put(CommentsTable.KEY_COMMENT_UNIQUE_ID, CommentsTable.KEY_COMMENT_UNIQUE_ID);
+		PROJECTION_MAP.put(CommentsTable.KEY_COMMENT_ORIGINAL_TITLE, CommentsTable.KEY_COMMENT_ORIGINAL_TITLE);
+		PROJECTION_MAP.put(CommentsTable.KEY_COMMENT_ORIGINAL_TEXT,	CommentsTable.KEY_COMMENT_ORIGINAL_TEXT);
+		PROJECTION_MAP.put(CommentsTable.KEY_COMMENT_UNIQUE_ID, CommentsTable.KEY_COMMENT_UNIQUE_ID);
 
 	}
 

--- a/src/com/github/andlyticsproject/model/Comment.java
+++ b/src/com/github/andlyticsproject/model/Comment.java
@@ -14,10 +14,14 @@ public class Comment extends Statistic {
 	// looks like this: 'gp:AOqpTOGnebkY.....'
 	private String uniqueId;
 
+	private String title;
+	
 	// this is either the translated text, or the same as originalText, 
 	// depending on display language (current locale)
 	private String text;
 
+	private String originalTitle;
+	
 	// text in original language
 	private String originalText;
 
@@ -51,6 +55,14 @@ public class Comment extends Statistic {
 	public void setUniqueId(String uniqueId) {
 		this.uniqueId = uniqueId;
 	}
+	
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
 
 	public String getText() {
 		return text;
@@ -60,6 +72,14 @@ public class Comment extends Statistic {
 		this.text = text;
 	}
 
+	public String getOriginalTitle() {
+		return originalTitle;
+	}
+
+	public void setOriginalTitle(String originalTitle) {
+		this.originalTitle = originalTitle;
+	}
+	
 	public String getOriginalText() {
 		return originalText;
 	}


### PR DESCRIPTION
**Example comment (anonymised):**

``` json
{"3":"1392410977213","2":"Jon Doe","10":true,"1":"gp:XXXXXXXXXXXXXXX","7":"1.0.0.0","6":100,"5":{"3":"Booom","2":"Muito bom.","1":"pt_BR"},"4":4,"8":{"3":"Manufactor","2":["Device"],"1":"xxxxx"},"11":{"2":"Very good.","1":"en-US","4":"pt"}}
```

The last part under PARENT:"11" does not contain a CHILD:"3" which would be the translated comment body, but the source, PARENT:"5" has a CHILD:"3" with the text "Booom", which is missing in the translation.
If we google translate from **pt** to **en** source and translation are the same, this could be the explanation. 
