### PR TITLE
Don't fail if UserDetails does not have a preferred currency

### DIFF
--- a/src/com/github/andlyticsproject/console/v2/BaseAuthenticator.java
+++ b/src/com/github/andlyticsproject/console/v2/BaseAuthenticator.java
@@ -135,7 +135,9 @@ public abstract class BaseAuthenticator implements DevConsoleAuthenticator {
 			}
 
 			JSONObject userDetails = new JSONObject(startupData.getString("UserDetails"));
-			result = userDetails.getString("2");
+			if (userDetails.has("2")) {
+				result = userDetails.getString("2");
+			}
 
 			return result;
 		} catch (JSONException e) {


### PR DESCRIPTION
On an account with a single free app, the UserDetails object does not have a preferred currency

See #629
