### PR TITLE
Use design time attributes to assist layouting and value preview.

### DIFF
--- a/res/layout/base_chart_headline.xml
+++ b/res/layout/base_chart_headline.xml
@@ -1,4 +1,5 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content" >
 
@@ -29,7 +30,8 @@
             android:text="@string/app_name"
             android:textColor="#F7FBF5"
             android:textSize="15dp"
-            android:textStyle="bold" />
+            android:textStyle="bold"
+            tools:textColor="@android:color/black" />
     </RelativeLayout>
 
 </RelativeLayout>

--- a/res/layout/comments.xml
+++ b/res/layout/comments.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
 	xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:tools="http://schemas.android.com/tools"
 	android:layout_width="fill_parent"
 	android:layout_height="fill_parent"
 	android:background="@color/andBackground">
@@ -23,7 +24,8 @@
 			android:dividerHeight="1dp"
 			android:paddingTop="5dp"
 			android:background="@color/andBackground"
-			android:divider="@color/andBackground" />
+			android:divider="@color/andBackground"
+			tools:listitem="@layout/comments_list_item_comment" />
 
 		<RelativeLayout
 			android:id="@+id/comments_nocomments"

--- a/res/layout/comments_fragment.xml
+++ b/res/layout/comments_fragment.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
 	xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:tools="http://schemas.android.com/tools"
 	android:layout_width="fill_parent"
 	android:layout_height="fill_parent"
 	android:background="@color/andBackground">
@@ -23,7 +24,8 @@
 			android:dividerHeight="1dp"
 			android:paddingTop="5dp"
 			android:background="@color/andBackground"
-			android:divider="@color/andBackground" />
+			android:divider="@color/andBackground"
+			tools:listitem="@layout/comments_list_item_comment" />
 
 		<RelativeLayout
 			android:id="@+id/comments_nocomments"

--- a/res/layout/comments_list_item_comment.xml
+++ b/res/layout/comments_list_item_comment.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/comments_list_item_app_row"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
@@ -32,7 +33,8 @@
             android:paddingLeft="5dp"
             android:paddingRight="10dp"
             android:paddingTop="10dp"
-            android:textIsSelectable="false" >
+            android:textIsSelectable="false"
+            android:text="User name" >
         </TextView>
 
         <ImageView
@@ -53,7 +55,8 @@
             android:paddingLeft="20dp"
             android:paddingRight="20dp"
             android:textIsSelectable="false"
-            android:textStyle="bold" />
+            android:textStyle="bold"
+            tools:text="Comment title" />
 
         <TextView
             android:id="@+id/comments_list_item_text"
@@ -64,7 +67,8 @@
             android:paddingLeft="20dp"
             android:paddingRight="20dp"
             android:textColor="#676767"
-            android:textIsSelectable="false" />
+            android:textIsSelectable="false"
+            tools:text="Comment message" />
     </RelativeLayout>
 
     <LinearLayout
@@ -91,7 +95,8 @@
             android:paddingRight="4dp"
             android:singleLine="true"
             android:textColor="#8F9698"
-            android:textIsSelectable="false" />
+            android:textIsSelectable="false"
+            tools:text="1.2.3" />
 
         <TextView
             android:id="@+id/comments_list_item_device"
@@ -106,7 +111,8 @@
             android:paddingRight="4dp"
             android:singleLine="true"
             android:textColor="#8F9698"
-            android:textIsSelectable="false" />
+            android:textIsSelectable="false"
+            tools:text="Google Nexus 5" />
 
         <TextView
             android:id="@+id/comments_list_item_language"
@@ -118,7 +124,8 @@
             android:drawablePadding="4dp"
             android:gravity="left|center_vertical"
             android:textColor="#8F9698"
-            android:textIsSelectable="false" />
+            android:textIsSelectable="false"
+            tools:text="EN" />
     </LinearLayout>
 
     <View

--- a/res/layout/comments_list_item_group_header.xml
+++ b/res/layout/comments_list_item_group_header.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content" >
 
@@ -13,6 +14,7 @@
         android:paddingLeft="10dp"
         android:paddingRight="10dp"
         android:paddingTop="12dp"
-        android:textStyle="bold" />
+        android:textStyle="bold"
+        tools:text="Monday, February 22, 2015" />
 
 </RelativeLayout>

--- a/res/layout/comments_list_item_reply.xml
+++ b/res/layout/comments_list_item_reply.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:paddingLeft="15dp"
@@ -33,7 +34,8 @@
             android:layout_height="wrap_content"
             android:layout_toRightOf="@+id/comments_list_item_username"
             android:paddingLeft="5dp"
-            android:paddingRight="5dp" >
+            android:paddingRight="5dp"
+            tools:text="Monday, February 22, 2015" >
         </TextView>
 
         <TextView
@@ -47,7 +49,8 @@
             android:paddingLeft="20dp"
             android:paddingRight="20dp"
             android:paddingTop="5dp"
-            android:paddingBottom="10dp" />
+            android:paddingBottom="10dp"
+            tools:text="Reply message" />
     </RelativeLayout>
 
 </FrameLayout>

--- a/res/layout/main_list_item.xml
+++ b/res/layout/main_list_item.xml
@@ -1,4 +1,5 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
     android:background="@color/andBackground"
@@ -54,7 +55,8 @@
                 android:layout_height="wrap_content"
                 android:layout_toRightOf="@+id/main_app_icon_frame"
                 android:maxLines="1"
-                android:textStyle="bold" />
+                android:textStyle="bold"
+                tools:text="Andlytics" />
 
             <RatingBar
                 android:id="@+id/main_app_ratingbar"
@@ -80,7 +82,8 @@
                 android:minWidth="65dp"
                 android:paddingBottom="2dp"
                 android:paddingRight="5dp"
-                android:paddingTop="2dp">  
+                android:paddingTop="2dp"
+                tools:text="100">
             </TextView>
 
             <TextView
@@ -101,7 +104,8 @@
                 android:layout_height="wrap_content"
                 android:layout_alignBaseline="@+id/main_app_commentscountText"
                 android:layout_alignParentRight="true"
-                android:paddingRight="50dp" />
+                android:paddingRight="50dp"
+                tools:text="10.0%" />
         </RelativeLayout>
         
         <RelativeLayout
@@ -138,7 +142,8 @@
                 android:minWidth="70dp"
                 android:paddingLeft="10dp"
                 android:paddingRight="5dp"
-                android:paddingTop="3dp" />
+                android:paddingTop="3dp"
+                tools:text="1000"/>
 
             <TextView
                 android:id="@+id/main_app_downloadsText"
@@ -157,7 +162,8 @@
                 android:layout_alignBaseline="@+id/main_app_downloadsText"
                 android:layout_alignParentRight="true"
                 android:paddingRight="55dp"
-                android:text="" />
+                android:text=""
+                tools:text="50.0%" />
 
             <TextView
                 android:id="@+id/main_app_activeinstalls"
@@ -168,7 +174,8 @@
                 android:layout_below="@+id/main_app_downloads"
                 android:gravity="right"
                 android:paddingBottom="3dp"
-                android:paddingRight="5dp" />
+                android:paddingRight="5dp"
+                tools:text="500" />
 
             <TextView
                 android:id="@+id/main_app_activeinstallsText"
@@ -188,7 +195,8 @@
                 android:layout_height="wrap_content"
                 android:layout_alignBaseline="@+id/main_app_activeinstallsText"
                 android:layout_alignParentRight="true"
-                android:paddingRight="55dp" />
+                android:paddingRight="55dp"
+                tools:text="50.0%" />
         </RelativeLayout>
         
         <RelativeLayout
@@ -225,7 +233,8 @@
                 android:minWidth="70dp"
                 android:paddingLeft="10dp"
                 android:paddingRight="5dp"
-                android:paddingTop="3dp" />
+                android:paddingTop="3dp"
+                tools:text="1" />
 
             <TextView
                 android:id="@+id/main_app_revenue_total_label"
@@ -244,7 +253,8 @@
                 android:layout_height="wrap_content"
                 android:layout_alignBaseline="@+id/main_app_revenue_total_text"
                 android:layout_alignParentRight="true"
-                android:paddingRight="55dp" />
+                android:paddingRight="55dp"
+                tools:text="10.0%" />
 
             <TextView
                 android:id="@+id/main_app_revenue_last_30days_text"
@@ -256,7 +266,8 @@
                 android:minWidth="70dp"
                 android:paddingLeft="10dp"
                 android:paddingRight="5dp"
-                android:paddingBottom="3dp" />
+                android:paddingBottom="3dp"
+                tools:text="1" />
 
             <TextView
                 android:id="@+id/main_app_revenue_last_30days_label"
@@ -302,7 +313,8 @@
                 android:minWidth="70dp"
                 android:paddingLeft="10dp"
                 android:paddingRight="5dp"
-                android:paddingTop="3dp" />
+                android:paddingTop="3dp"
+                tools:text="100" />
 
             <TextView
                 android:id="@+id/main_app_admob_revenue_text"
@@ -322,7 +334,8 @@
                 android:layout_alignBaseline="@+id/main_app_admob_revenue_text"
                 android:layout_alignParentRight="true"
                 android:paddingRight="55dp"
-                android:text="" />
+                android:text=""
+                tools:text="20.5%" />
 
             <TextView
                 android:id="@+id/main_app_admob_requests"
@@ -333,7 +346,8 @@
                 android:layout_below="@+id/main_app_admob_revenue"
                 android:gravity="right"
                 android:paddingBottom="3dp"
-                android:paddingRight="5dp" />
+                android:paddingRight="5dp"
+                tools:text="50"/>
 
             <TextView
                 android:id="@+id/main_app_admob_requests_text"
@@ -354,7 +368,8 @@
                 android:layout_alignBaseline="@+id/main_app_admob_requests_text"
                 android:layout_alignParentRight="true"
                 android:paddingRight="55dp"
-                android:text="" />
+                android:text=""
+                tools:text="11.8%" />
         </RelativeLayout>
 
         <RelativeLayout
@@ -392,7 +407,8 @@
                 android:layout_below="@+id/main_app_spacer2"
                 android:maxLines="1"
                 android:paddingRight="5dp"
-                android:paddingTop="2dp" >
+                android:paddingTop="2dp"
+                tools:text="4.750">
             </TextView>
 
             <TextView
@@ -414,7 +430,8 @@
                 android:gravity="right"
                 android:minWidth="70dp"
                 android:paddingBottom="5dp"
-                android:paddingRight="5dp" >
+                android:paddingRight="5dp"
+                tools:text="200" >
             </TextView>
 
             <TextView
@@ -424,7 +441,8 @@
                 android:layout_height="wrap_content"
                 android:layout_alignBaseline="@+id/main_app_avgrating"
                 android:layout_alignParentRight="true"
-                android:paddingRight="55dp" />
+                android:paddingRight="55dp"
+                tools:text="23.3%" />
 
             <TextView
                 android:id="@+id/main_app_ratingText"
@@ -444,7 +462,8 @@
                 android:layout_height="wrap_content"
                 android:layout_alignBaseline="@+id/main_app_ratingText"
                 android:layout_alignParentRight="true"
-                android:paddingRight="55dp" />
+                android:paddingRight="55dp"
+                tools:text="17.2%" />
 
             <View
                 android:id="@+id/main_app_spacer3"


### PR DESCRIPTION
I added [Design Time Attributes][dta] which are useful to **render meaningful previews** for the layout files in Android Studio. They also help to optimize layout in general. Further you can **add placeholders** for text and image elements. I use strong **background colors** for text fields and image views to preview their exact dimensions and margins.
None of these changes affects the compiled application code.

Here is an extreme example for *layout/comments_list_item_comment.xml*:

## Preview without Design Time Attributes

![andlytics-without-design-time-attributes](https://cloud.githubusercontent.com/assets/144518/6328394/40dff7f2-bb67-11e4-8a38-f15706134c4d.png)

## Preview with Design Time Attributes

![andlytics-with-design-time-attributes](https://cloud.githubusercontent.com/assets/144518/6328397/44fb3324-bb67-11e4-9763-11cd8b8073c6.png)





[dta]: http://tools.android.com/tips/layout-designtime-attributes