### PR TITLE
Fix for linked accounts that cannot access apps

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -156,6 +156,7 @@
     <string name="network_error">A network error has occurred. Please try again later</string>
     <string name="signup_error">%1$s is not an android developer account, sign up at:\n\n %2$s</string>
     <string name="auth_error">Authentication failed for: %1$s</string>
+    <string name="app_access_blocked_error">Not allowed to access apps for: %1$s</string>
     <string name="auth_error_open_browser">Additional authentication required. Tap to login via browser.</string>
     <string name="admob_ratelimit_error">Can\'t load Admob data because Admob has restricted the number of requests from this app, try again later</string>
     <string name="admob_missing_error">AdMob account %1$s is missing. If this happens repeatedly try moving Andlytics from SD card to internal storage</string>

--- a/src/com/github/andlyticsproject/BaseActivity.java
+++ b/src/com/github/andlyticsproject/BaseActivity.java
@@ -20,6 +20,7 @@ import com.github.andlyticsproject.admob.AdmobGenericException;
 import com.github.andlyticsproject.admob.AdmobInvalidRequestException;
 import com.github.andlyticsproject.admob.AdmobInvalidTokenException;
 import com.github.andlyticsproject.admob.AdmobRateLimitExceededException;
+import com.github.andlyticsproject.console.AppAccessBlockedException;
 import com.github.andlyticsproject.console.AuthenticationException;
 import com.github.andlyticsproject.console.DevConsoleProtocolException;
 import com.github.andlyticsproject.console.MultiAccountException;
@@ -108,6 +109,9 @@ public class BaseActivity extends Activity {
 		if (e instanceof NetworkException) {
 			Toast.makeText(BaseActivity.this, getString(R.string.network_error), Toast.LENGTH_LONG)
 					.show();
+		} else if (e instanceof AppAccessBlockedException) {
+			Toast.makeText(BaseActivity.this, getString(R.string.app_access_blocked_error, accountName),
+					Toast.LENGTH_LONG).show();
 		} else if (e instanceof AuthenticationException) {
 			Toast.makeText(BaseActivity.this, getString(R.string.auth_error, accountName),
 					Toast.LENGTH_LONG).show();

--- a/src/com/github/andlyticsproject/console/AppAccessBlockedException.java
+++ b/src/com/github/andlyticsproject/console/AppAccessBlockedException.java
@@ -1,0 +1,8 @@
+package com.github.andlyticsproject.console;
+
+public class AppAccessBlockedException extends DevConsoleException {
+
+	public AppAccessBlockedException(String message) {
+		super(message);
+	}
+}

--- a/src/com/github/andlyticsproject/console/v2/DevConsoleV2.java
+++ b/src/com/github/andlyticsproject/console/v2/DevConsoleV2.java
@@ -191,7 +191,7 @@ public class DevConsoleV2 implements DevConsole {
 	}
 
 	/**
-	 * Fetches a combined list of apps for all avaiable console accounts
+	 * Fetches a combined list of apps for all available console accounts
 	 * 
 	 * @return combined list of apps
 	 * @throws DevConsoleException
@@ -201,6 +201,10 @@ public class DevConsoleV2 implements DevConsole {
 		for (DeveloperConsoleAccount consoleAccount : protocol.getSessionCredentials()
 				.getDeveloperConsoleAccounts()) {
 			String developerId = consoleAccount.getDeveloperId();
+			if (!consoleAccount.getCanAccessApps()) {
+				Log.w(TAG, "Not allowed to fetch app info for " + developerId);
+				continue;
+			}
 			Log.d(TAG, "Getting apps for " + developerId);
 			String response = post(protocol.createFetchAppsUrl(developerId),
 					protocol.createFetchAppInfosRequest(), developerId);

--- a/src/com/github/andlyticsproject/model/DeveloperConsoleAccount.java
+++ b/src/com/github/andlyticsproject/model/DeveloperConsoleAccount.java
@@ -4,10 +4,12 @@ public class DeveloperConsoleAccount {
 
 	private String developerId;
 	private String name;
+	private boolean canAccessApps;
 
-	public DeveloperConsoleAccount(String developerId, String name) {
+	public DeveloperConsoleAccount(String developerId, String name, boolean canAccessApps) {
 		this.developerId = developerId;
 		this.name = name;
+		this.canAccessApps = canAccessApps;
 	}
 
 	public String getDeveloperId() {
@@ -16,6 +18,10 @@ public class DeveloperConsoleAccount {
 
 	public String getName() {
 		return name;
+	}
+
+	public boolean getCanAccessApps() {
+		return canAccessApps;
 	}
 
 	@Override
@@ -38,8 +44,8 @@ public class DeveloperConsoleAccount {
 
 	@Override
 	public String toString() {
-		return String
-				.format("DeveloperConsoleAccount [developerId=%s, name=%s]", developerId, name);
+		return String.format("DeveloperConsoleAccount [developerId=%s, name=%s, canAccessApps=%b]",
+				developerId, name, canAccessApps);
 	}
 
 }


### PR DESCRIPTION
Fix for #664 

Not sure about how best to report the problem when it affects some accounts. Currently the only idication that something is wrong if some accounts are allowed but others are not is a log message which is not ideal. But we don't want to notify the user every time as they may not be able to fix it.
This would be solved if we presented each linked account as a seperate account that the user could switch to, but that requries quite a bit of work.