### PR TITLE
fix JSONException in parseRatings

### DIFF
--- a/src/com/github/andlyticsproject/console/v2/JsonParser.java
+++ b/src/com/github/andlyticsproject/console/v2/JsonParser.java
@@ -53,11 +53,11 @@ public class JsonParser {
 	static void parseRatings(String json, AppStats stats) throws JSONException {
 		// Extract just the array with the values
 		JSONObject values = new JSONObject(json).getJSONObject("result").getJSONArray("1")
-				.getJSONObject(0);
+				.getJSONObject(0).getJSONObject("8");
 
-		// Ratings are at index 2 - 6
-		stats.setRating(values.getInt("2"), values.getInt("3"), values.getInt("4"),
-				values.getInt("5"), values.getInt("6"));
+		// Ratings are at index 1 - 5
+		stats.setRating(values.getInt("1"), values.getInt("2"), values.getInt("3"),
+				values.getInt("4"), values.getInt("5"));
 
 	}
 


### PR DESCRIPTION
Hey,

starting today I got following exception:
```com.github.andlyticsproject E/Main﹕ Error while requesting developer console : com.github.andlyticsproject.console.v2.DevConsoleV2Protocol.parseRatingsResponse(DevConsoleV2Protocol.java:212)
    com.github.andlyticsproject.console.v2.DevConsoleV2.fetchRatings(DevConsoleV2.java:290)
    com.github.andlyticsproject.console.v2.DevConsoleV2.fetchAppInfosAndStatistics(DevConsoleV2.java:122)
    com.github.andlyticsproject.console.v2.DevConsoleV2.getAppInfo(DevConsoleV2.java:103)
    com.github.andlyticsproject.Main$LoadRemoteEntries.doInBackground(Main.java:521)
    com.github.andlyticsproject.Main$LoadRemoteEntries.doInBackground(Main.java:488)```

The pull requests fixes this.