### PR TITLE
Prevent parsing problem when app has no IconUrl

### DIFF
--- a/src/com/github/andlyticsproject/console/v2/JsonParser.java
+++ b/src/com/github/andlyticsproject/console/v2/JsonParser.java
@@ -248,7 +248,9 @@ public class JsonParser {
 			app.setDetails(details);
 
 			app.setVersionName(jsonAppDetails.getString("4"));
-			app.setIconUrl(jsonAppDetails.getString("3"));
+			if (jsonAppDetails.has("3")) {
+				app.setIconUrl(jsonAppDetails.getString("3"));
+			}
 
 
 


### PR DESCRIPTION
For me Andlytics was not working for a while ( not updating any app ) - digged a bit into it and this is the issue. I do not know how I ended up having an app with no icon-url - but it is the case - adding this check works for me - might also work for others