### PR TITLE
Preview strings with variable names and example values.

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
     <string name="one_entry_hint_desc">Andlytics collects data over time. to see a meaningful chart come back as soon as more data is available.
         \n\nUsually download stats are updated every 24&#8211;48 hours.</string>
@@ -115,15 +115,15 @@
     <string name="notification_title">Andlytics change detection</string>
     <string name="import_">Import</string>
     <string name="import_no_sdcard_or_file">SD-Card not mounted or invalid file format, can\'t import!</string>
-    <string name="import_no_stats_file">Stats file not found: %1$s</string>
+    <string name="import_no_stats_file">Stats file not found: <xliff:g id="fileName">%1$s</xliff:g></string>
     <string name="import_no_app">No app selected, can\'t import!</string>
     <string name="importing">Importing</string>
     <string name="import_started">Import started.</string>
     <string name="import_finished">Import finished.</string>
-    <string name="imported_apps">Imported %d apps.</string>
+    <string name="imported_apps">Imported <xliff:g example="23" id="appsCount">%d</xliff:g> apps.</string>
     <string name="import_error">Error during import.</string>
     <string name="import_confirm_dialog_title">Confirm import</string>
-    <string name="import_confirm_dialog_message">You already have stats for %d apps. Importing will overwrite them. Continue with import?</string>
+    <string name="import_confirm_dialog_message">You already have stats for <xliff:g example="23" id="appsCount">%d</xliff:g> apps. Importing will overwrite them. Continue with import?</string>
     <string name="export_">Export</string>
     <string name="export_no_sdcard">SD-Card not mounted, can\'t export!</string>
     <string name="export_no_app">No app selected, can\'t export!</string>
@@ -132,7 +132,7 @@
     <string name="export_failed_to_load_stats">Failed to load app stats.</string>
     <string name="export_saved_to">Saved to</string>
     <string name="export_confirm_dialog_title">Confirm export</string>
-    <string name="export_confirm_dialog_message">An export file \'%s\' already exits. Exporting app stats will overwrite it. Continue with export?</string>
+    <string name="export_confirm_dialog_message">An export file \'<xliff:g example="andlytics.zip" id="fileName">%s</xliff:g>\' already exits. Exporting app stats will overwrite it. Continue with export?</string>
     <string name="share">Share</string>
     <string name="manage_accounts">Manage accounts</string>
     <string name="preferences">Preferences</string>
@@ -154,12 +154,12 @@
 
     <!-- Errors -->
     <string name="network_error">A network error has occurred. Please try again later</string>
-    <string name="signup_error">%1$s is not an android developer account, sign up at:\n\n %2$s</string>
-    <string name="auth_error">Authentication failed for: %1$s</string>
-    <string name="app_access_blocked_error">Not allowed to access apps for: %1$s</string>
+    <string name="signup_error"><xliff:g id="accountName">%1$s</xliff:g> is not an android developer account, sign up at:\n\n <xliff:g id="uri">%2$s</xliff:g></string>
+    <string name="auth_error">Authentication failed for: <xliff:g id="accountName">%1$s</xliff:g></string>
+    <string name="app_access_blocked_error">Not allowed to access apps for: <xliff:g id="accountName">%1$s</xliff:g></string>
     <string name="auth_error_open_browser">Additional authentication required. Tap to login via browser.</string>
     <string name="admob_ratelimit_error">Can\'t load Admob data because Admob has restricted the number of requests from this app, try again later</string>
-    <string name="admob_missing_error">AdMob account %1$s is missing. If this happens repeatedly try moving Andlytics from SD card to internal storage</string>
+    <string name="admob_missing_error">AdMob account <xliff:g id="accountName">%1$s</xliff:g> is missing. If this happens repeatedly try moving Andlytics from SD card to internal storage</string>
     <string name="admob_invalid_request_error">Error while requesting AdMob API</string>
     <string name="admob_invalid_token_error">Error while authenticating AdMob account. Please try again later</string>
     <string name="admob_generic_error">Unable to load Admob data, please try again later</string>
@@ -206,7 +206,7 @@
     <string name="revenue_last_30days">30 days revenue</string>
     <string name="show_developer_cut_revenue">Show developer cut of revenue</string>
     <string name="show_developer_cut_revenue_summary">Show developer cut of sales revenue (70%).</string>
-    <string name="account_authorization_denied">Authorization for account \'%s\' denied.</string>
+    <string name="account_authorization_denied">Authorization for account \'<xliff:g id="accountName">%s</xliff:g>\' denied.</string>
     <string name="use_new_admob">Use new AdMob</string>
 
 </resources>


### PR DESCRIPTION
I wrapped variables in strings into XLIFF to facilitate preview renderings in Android Studio which show either the variable name or an example value.
Here are two example screenshots:

![example1](https://cloud.githubusercontent.com/assets/144518/12935393/b04be86a-cf95-11e5-9aa9-719ad0125bd5.png)
![example2](https://cloud.githubusercontent.com/assets/144518/12935397/b2cd754a-cf95-11e5-987f-e4f9214ee3af.png)
